### PR TITLE
Lua 5.1 minimum compatibility

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Luacheck
-        uses: lunarmodules/luacheck@v0
+        uses: lunarmodules/luacheck@v1

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,4 +1,4 @@
-std = "max"
+std = "min+sile"
 include_files = {
   "**/*.lua",
   "sile.in",
@@ -18,15 +18,6 @@ exclude_files = {
 }
 files["**/*_spec.lua"] = {
   std = "+busted"
-}
-globals = {
-  "SILE",
-  "SU",
-  "luautf8",
-  "pl",
-  "fluent",
-  "SYSTEM_SILE_PATH",
-  "SHARED_LIB_EXT"
 }
 max_line_length = false
 ignore = {


### PR DESCRIPTION
See https://github.com/Omikhleia/resilient.sile/pull/70

```
silex/fixes.lua:174:23: accessing undefined field searchpath of global package
```

IIRC, that line was copied from SILE.