### PR TITLE
Fix 0.4.0 mess

### DIFF
--- a/silex.sile-0.4.1-1.rockspec
+++ b/silex.sile-0.4.1-1.rockspec
@@ -1,9 +1,9 @@
 rockspec_format = "3.0"
 package = "silex.sile"
-version = "0.4.0-1"
+version = "0.4.1-1"
 source = {
   url = "git+https://github.com/Omikhleia/silex.sile.git",
-  tag = "v0.4.0",
+  tag = "v0.4.1",
 }
 description = {
   summary = "Extension layer for SILE and resilient",

--- a/silex/override.lua
+++ b/silex/override.lua
@@ -9,10 +9,24 @@ require = function (name) -- luacheck: ignore
   if ok then
     if not loaded[name] then
       loaded[name] = mod
-      SU.debug("silex", "Loaded silex version of " .. name)
+      SU.debug("silex", "Loaded silex version of", name)
     end
     return mod
   end
   loaded[name] = originalRequire(name)
   return loaded[name]
+end
+
+if SILE.outputters then
+  -- Outputters are loaded before the override, at SILE.init().
+  -- We come late to the party, so we need to reload them for our override to work.
+  -- Is this fragile? Yes. Is it a hack? Yes. Does it work? Yes.
+  for k, _ in pairs(SILE.outputters) do
+    SU.debug("silex", "Re-loading outputter", k)
+    SILE.outputters[k] = require("outputters." .. k)
+  end
+  if SILE.outputter then
+    SU.debug("silex", "Re-instanciating current outputter", SILE.outputter._name)
+    SILE.outputter = SILE.outputters[SILE.outputter._name]()
+  end
 end


### PR DESCRIPTION
See https://github.com/Omikhleia/silex.sile/pull/8#issuecomment-1913286386

Oops, the changes introduced in 0.4.0 were incomplete and breaking...

**Fixes**
- Outputter overriding from 0.4.0 needs a hack of sorts to work properly...

**Features**

Let's take that opportunity for sile·x to backport some more changes from the 0.15 develop branch, so we can start preparing depending modules.

- Advance compatibility with `SU.ast` from SILE 0.15 develop