### PR TITLE
Multi-line effects

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -21,6 +21,7 @@ files["**/*_spec.lua"] = {
 }
 max_line_length = false
 ignore = {
-  "581" -- operator order warning doesn't account for custom table metamethods
+  "581", -- operator order warning doesn't account for custom table metamethods
+  "212/self" -- unused argument self: counterproductive warning
 }
 -- vim: ft=lua

--- a/silex/outputters/base.lua
+++ b/silex/outputters/base.lua
@@ -2,11 +2,29 @@ local outputter = pl.class()
 outputter.type = "outputter"
 outputter._name = "base"
 
-function outputter._init () end
+function outputter:_init ()
+   self.hooks = {}
+   return self
+end
+
+function outputter:registerHook (category, func)
+   if not self.hooks[category] then self.hooks[category] = {} end
+   table.insert(self.hooks[category], func)
+end
+
+function outputter:runHooks (category, data)
+  if not self.hooks[category] then return nil end
+  for _, func in ipairs(self.hooks[category]) do
+    data = func(self, data)
+  end
+  return data
+end
 
 function outputter.newPage () end
 
-function outputter.finish () end
+function outputter:finish ()
+  self:runHooks("prefinish")
+end
 
 function outputter.getCursor () end
 
@@ -34,15 +52,17 @@ function outputter.debugFrame (_, _, _) end
 
 function outputter.debugHbox (_, _, _) end
 
-function outputter.linkAnchor (_, _, _) end -- Unstable API
+function outputter.setLinkAnchor (_, _, _) end -- Unstable API
 
-function outputter.enterLinkTarget (_, _, _) end -- Unstable API
+function outputter.beginLink (_, _, _) end -- Unstable API
 
-function outputter.leaveLinkTarget (_, _, _, _, _, _, _) end -- Unstable API
+function outputter.endLink (_, _, _, _, _, _, _) end -- Unstable API
 
 function outputter.setMetadata (_, _, _) end
 
 function outputter.setBookmark (_, _, _) end
+
+function outputter.drawRaw (_) end
 
 function outputter:getOutputFilename ()
   local fname

--- a/silex/outputters/debug.lua
+++ b/silex/outputters/debug.lua
@@ -1,0 +1,190 @@
+local base = require("outputters.base")
+
+local cursorX = 0
+local cursorY = 0
+
+local started = false
+
+local lastFont
+local outfile
+
+local function _round (input)
+  -- LuaJIT 2.1 betas (and inheritors such as OpenResty and Moonjit) are biased
+  -- towards rounding 0.5 up to 1, all other Lua interpreters are biased
+  -- towards rounding such floating point numbers down.  This hack shaves off
+  -- just enough to fix the bias so our test suite works across interpreters.
+  -- Note that even a true rounding function here will fail because the bias is
+  -- inherent to the floating point type. Also note we are erroring in favor of
+  -- the *less* common option because the LuaJIT VMS are hopelessly broken
+  -- whereas normal LUA VMs can be cooerced.
+  if input > 0 then input = input + .00000000000001 end
+  if input < 0 then input = input - .00000000000001 end
+  return string.format("%.4f", input)
+end
+
+local outputter = pl.class(base)
+outputter._name = "debug"
+outputter.extension = "debug"
+
+-- The outputter init can't actually initialize output (as logical as it might
+-- have seemed) because that requires a page size which we don't know yet.
+-- function outputter:_init () end
+
+function outputter:_ensureInit ()
+  if not started then
+    started = true -- keep this before self:_writeline or it will be a race condition!
+    local fname = self:getOutputFilename()
+    outfile = fname == "-" and io.stdout or io.open(fname, "w+")
+    if SILE.documentState.paperSize then
+      self:_writeline("Set paper size ", SILE.documentState.paperSize[1], SILE.documentState.paperSize[2])
+    end
+    self:_writeline("Begin page")
+  end
+end
+
+function outputter:_writeline (...)
+  self:_ensureInit()
+  local args = pl.utils.pack(...)
+  for i = 1, #args do
+    outfile:write(args[i])
+    if i < #args then outfile:write("\t") end
+  end
+  outfile:write("\n")
+end
+
+function outputter:newPage ()
+  self:_writeline("New page")
+end
+
+function outputter:finish ()
+  if SILE.status.unsupported then self:_writeline("UNSUPPORTED") end
+  self:_writeline("End page")
+  self:runHooks("prefinish")
+  self:_writeline("Finish")
+  outfile:close()
+end
+
+function outputter.getCursor (_)
+  return cursorX, cursorY
+end
+
+function outputter:setCursor (x, y, relative)
+  x = SU.cast("number", x)
+  y = SU.cast("number", y)
+  local oldx, oldy = self:getCursor()
+  local offset = relative and { x = cursorX, y = cursorY } or { x = 0, y = 0 }
+  cursorX = offset.x + x
+  cursorY = offset.y - y
+  if _round(oldx) ~= _round(cursorX) then self:_writeline("Mx ", _round(x)) end
+  if _round(oldy) ~= _round(cursorY) then self:_writeline("My ", _round(y)) end
+end
+
+function outputter:setColor (color)
+  if color.r then
+    self:_writeline("Set color", _round(color.r), _round(color.g), _round(color.b))
+  elseif color.c then
+    self:_writeline("Set color", _round(color.c), _round(color.m), _round(color.y), _round(color.k))
+  elseif color.l then
+    self:_writeline("Set color", _round(color.l))
+  end
+end
+
+function outputter:pushColor (color)
+  if color.r then
+    self:_writeline("Push color", _round(color.r), _round(color.g), _round(color.b))
+  elseif color.c then
+    self:_writeline("Push color (CMYK)", _round(color.c), _round(color.m), _round(color.y), _round(color.k))
+  elseif color.l then
+    self:_writeline("Push color (grayscale)", _round(color.l))
+  end
+end
+
+function outputter:popColor ()
+  self:_writeline("Pop color")
+end
+
+function outputter:drawHbox (value, width)
+  if not value.glyphString then return end
+  width = SU.cast("number", width)
+  local buf
+  if value.complex then
+    local cluster = {}
+    for i = 1, #value.items do
+      local item = value.items[i]
+      cluster[#cluster+1] = item.gid
+      -- For the sake of terseness we're only dumping non-zero values
+      if item.glyphAdvance ~= 0 then cluster[#cluster+1] = "a=".._round(item.glyphAdvance) end
+      if item.x_offset then cluster[#cluster+1] = "x=".._round(item.x_offset) end
+      if item.y_offset then cluster[#cluster+1] = "y=".._round(item.y_offset) end
+      self:setCursor(item.width, 0, true)
+    end
+    buf = table.concat(cluster, " ")
+  else
+    buf = table.concat(value.glyphString, " ") .. " w=" .. _round(width)
+  end
+  self:_writeline("T", buf, "(" .. tostring(value.text) .. ")")
+end
+
+function outputter:setFont (options)
+  local font = SILE.font._key(options)
+  if lastFont ~= font then
+    self:_writeline("Set font ", font)
+    lastFont = font
+  end
+end
+
+function outputter:drawImage (src, x, y, width, height)
+  x = SU.cast("number", x)
+  y = SU.cast("number", y)
+  width = SU.cast("number", width)
+  height = SU.cast("number", height)
+  self:_writeline("Draw image", src, _round(x), _round(y), _round(width), _round(height))
+end
+
+function outputter.getImageSize (_, src, pageno)
+  local pdf = require("justenoughlibtexpdf")
+  local llx, lly, urx, ury, xresol, yresol = pdf.imagebbox(src, pageno)
+  return (urx-llx), (ury-lly), xresol, yresol
+end
+
+function outputter:drawSVG (figure, _, x, y, width, height, scalefactor)
+  x = SU.cast("number", x)
+  y = SU.cast("number", y)
+  width = SU.cast("number", width)
+  height = SU.cast("number", height)
+  self:_writeline("Draw SVG", _round(x), _round(y), _round(width), _round(height), figure, scalefactor)
+end
+
+function outputter:drawRule (x, y, width, depth)
+  x = SU.cast("number", x)
+  y = SU.cast("number", y)
+  width = SU.cast("number", width)
+  depth = SU.cast("number", depth)
+  self:_writeline("Draw line", _round(x), _round(y), _round(width), _round(depth))
+end
+
+function outputter:setLinkAnchor (name, x, y)
+  self:_writeline("Setting link anchor", name, x, y)
+end
+
+function outputter:beginLink (dest, opts)
+   self:_writeline("Begining a link", dest, opts)
+end
+
+function outputter:endLink(dest, opts, x0, y0, x1, y1)
+   self:_writeline("Ending a link", dest, opts, x0, y0, x1, y1)
+end
+
+function outputter:setBookmark (dest, title, level)
+   self:_writeline("Setting bookmark", dest, title, level)
+end
+
+function outputter:setMetadata (key, value)
+   self:_writeline("Set metadata", key, value)
+end
+
+function outputter:drawRaw (literal)
+   self:_writeline("Draw raw", literal)
+end
+
+return outputter

--- a/silex/packages/color/init.lua
+++ b/silex/packages/color/init.lua
@@ -14,9 +14,7 @@ function package:registerCommands ()
     -- (folio, footnotes, etc.)
     SILE.typesetter:liner("color", content, function (box, typesetter, line)
       SILE.outputter:pushColor(color)
-      for _, node in ipairs(box.inner) do
-        node:outputYourself(typesetter, line)
-      end
+      box:outputContent(typesetter, line)
       SILE.outputter:popColor()
     end)
   end, "Changes the active ink color to the color <color>.")

--- a/silex/packages/color/init.lua
+++ b/silex/packages/color/init.lua
@@ -1,0 +1,46 @@
+local base = require("packages.base")
+
+local package = pl.class(base)
+package._name = "color"
+
+function package:registerCommands ()
+
+  self:registerCommand("color", function (options, content)
+    local color = SILE.color(options.color or "black")
+    -- This is a bit of a hack to use a liner.
+    -- (Due to how the color stack is currently handled)
+    -- If the content spans multiple lines, and a page break occurs in between,
+    -- this avoids the color being propagated to other page content.
+    -- (folio, footnotes, etc.)
+    SILE.typesetter:liner("color", content, function (box, typesetter, line)
+      SILE.outputter:pushColor(color)
+      for _, node in ipairs(box.inner) do
+        node:outputYourself(typesetter, line)
+      end
+      SILE.outputter:popColor()
+    end)
+  end, "Changes the active ink color to the color <color>.")
+
+end
+
+package.documentation = [[
+\begin{document}
+The \autodoc:package{color} package allows you to temporarily change the color of the (virtual) ink that SILE uses to output text and rules.
+The package provides a \autodoc:command{\color} command which takes one parameter, \autodoc:parameter{color=<color specification>}, and typesets its argument in that color.
+
+The color specification is one of the following:
+\begin{itemize}
+\item{A RGB color in \code{#xxx} or \code{#xxxxxx} format, where \code{x} represents a hexadecimal digit, as often seen in HTML/CSS (\code{#000} is black, \code{#fff} is white, \code{#f00} is red, and so on);}
+\item{A RGB color as a series of three numeric values between 0 and 255 (e.g. \code{0 0 139} is a dark blue) or as three percentages;}
+\item{A CMYK color as a series of four numeric values between 0 and 255 or as four percentages;}
+\item{A grayscale color as a numeric value between 0 and 255;}
+\item{A (case-insensitive) named color, as one of the 148 keywords defined in the CSS Color Module Level 4. (Named colors resolve to RGB in the actual output.)}
+\end{itemize}
+
+So, for example, \color[color=red]{this text is typeset with \autodoc:command{\color[color=red]{…}}}.
+
+Here is a rule typeset with \autodoc:command{\color[color=#22dd33]}: \color[color=#22dd33]{\hrule[width=120pt,height=0.5pt]}
+\end{document}
+]]
+
+return package

--- a/silex/packages/cropmarks/init.lua
+++ b/silex/packages/cropmarks/init.lua
@@ -58,7 +58,7 @@ end
 function package:registerCommands ()
 
   self:registerCommand("cropmarks:header", function (_, _)
-    local info = SILE.masterFilename
+    local info = SILE.input.filenames[1]
        .. " - "
        .. self.class.packages.date:date({ format = "%x %X" })
        .. " - " .. outcounter
@@ -70,7 +70,7 @@ function package:registerCommands ()
   end)
 
   self:registerCommand("crop:setup", function (_, _)
-    SU.deprecated("crop:setup", "cropmarks:setup", "0.14.10", "0.17.0")
+    SU.deprecated("crop:setup", "cropmarks:setup", "0.15.10", "0.17.0")
     SILE.call("cropmarks:setup")
   end)
 end

--- a/silex/packages/pdf/init.lua
+++ b/silex/packages/pdf/init.lua
@@ -19,7 +19,7 @@ function package:registerCommands ()
         local x, y = state.cursorX, state.cursorY
         typesetter.frame:advancePageDirection(line.height)
         local _y = SILE.documentState.paperSize[2] - y
-        SILE.outputter:linkAnchor(x, _y, name)
+        SILE.outputter:setLinkAnchor(name, x, _y)
       end
     })
   end)
@@ -39,28 +39,8 @@ function package:registerCommands ()
     })
   end)
 
-  self:registerCommand("pdf:literal", function (_, content)
-    -- NOTE: This method is used by the pdfstructure package and should
-    -- probably be moved elsewhere, so there's no attempt here to delegate
-    -- the low-level libtexpdf call to te outputter.
-    if SILE.outputter._name ~= "libtexpdf" then
-      SU.error("pdf package requires libtexpdf backend")
-    end
-    local pdf = require("justenoughlibtexpdf")
-    if type(SILE.outputter._ensureInit) == "function" then
-      SILE.outputter:_ensureInit()
-    end
-    SILE.typesetter:pushHbox({
-      value = nil,
-      height = SILE.measurement(0),
-      width = SILE.measurement(0),
-      depth = SILE.measurement(0),
-      outputYourself = function (_, _, _)
-        pdf.add_content(content[1])
-      end
-    })
-  end)
-
+  -- TODO: Shim to pdfannotations package
+  -- self:registerCommand("pdf:literal", function (_, content)
   self:registerCommand("pdf:link", function (options, content)
     local dest = SU.required(options, "dest", "pdf:link")
     local external = SU.boolean(options.external, false)
@@ -74,7 +54,6 @@ function package:registerCommands ()
       borderwidth = borderwidth,
       borderoffset = borderoffset
     }
-
     local x0, y0
     SILE.typesetter:pushHbox({
       value = nil,
@@ -84,7 +63,7 @@ function package:registerCommands ()
       outputYourself = function (_, typesetter, _)
         x0 = typesetter.frame.state.cursorX:tonumber()
         y0 = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY):tonumber()
-        SILE.outputter:enterLinkTarget(dest, opts)
+        SILE.outputter:beginLink(dest, opts)
       end
     })
     local hbox, hlist = SILE.typesetter:makeHbox(content) -- hack
@@ -97,7 +76,7 @@ function package:registerCommands ()
       outputYourself = function (_, typesetter, _)
         local x1 = typesetter.frame.state.cursorX:tonumber()
         local y1 = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY + hbox.height):tonumber()
-        SILE.outputter:leaveLinkTarget(x0, y0, x1, y1, dest, opts) -- Unstable API
+        SILE.outputter:endLink(dest, opts, x0, y0, x1, y1) -- Unstable API
       end
     })
     SILE.typesetter:pushHlist(hlist)
@@ -120,15 +99,22 @@ package.documentation = [[
 The \autodoc:package{pdf} package enables basic support for PDF links and table-of-contents entries.
 It provides the four commands \autodoc:command{\pdf:destination}, \autodoc:command{\pdf:link}, \autodoc:command{\pdf:bookmark}, and \autodoc:command{\pdf:metadata}.
 
-The \autodoc:command{\pdf:destination} parameter creates a link target; it expects a parameter called \autodoc:parameter{name} to uniquely identify the target.
+The \autodoc:command{\pdf:destination} parameter creates a link target;
+   it expects a parameter called \autodoc:parameter{name} to uniquely identify the target.
 To create a link to that location in the document, use \autodoc:command{\pdf:link[dest=<name>]{<content>}}.
 
-The \autodoc:command{\pdf:link} command accepts several options defining its border style: a \autodoc:parameter{borderwidth} length setting the border width (defaults to \code{0}, meaning no border), a \autodoc:parameter{borderstyle} string (can be set to \code{underline} or \code{dashed}, otherwise a solid box), a \autodoc:parameter{bordercolor} color specification for this border (defaults to \code{blue}), and finally a \autodoc:parameter{borderoffset} length for adjusting the border with some vertical space above the content and below the baseline (defaults to \code{1pt}).
+The \autodoc:command{\pdf:link} command accepts several options defining its border style:
+   a \autodoc:parameter{borderwidth} length setting the border width (defaults to \code{0}, meaning no border),
+   a \autodoc:parameter{borderstyle} string (can be set to \code{underline} or \code{dashed}, otherwise a solid box),
+   a \autodoc:parameter{bordercolor} color specification for this border (defaults to \code{blue}),
+   and finally a \autodoc:parameter{borderoffset} length for adjusting the border with some vertical space above the content and below the baseline (defaults to \code{1pt}).
 Note that PDF renderers may vary on how they honor these border styling features on link annotations.
 
 It also has an \autodoc:parameter{external} option for URL links, which is not intended to be used directly—refer to the \autodoc:package{url} package for more flexibility typesetting external links.
 
-To set arbitrary key-value metadata, use something like \autodoc:command{\pdf:metadata[key=Author, value=J. Smith]}. The PDF metadata field names are case-sensitive. Common keys include \code{Title}, \code{Author}, \code{Subject}, \code{Keywords}, \code{CreationDate}, and \code{ModDate}.
+To set arbitrary key-value metadata, use something like \autodoc:command{\pdf:metadata[key=Author, value=J. Smith]}.
+The PDF metadata field names are case-sensitive.
+Common keys include \code{Title}, \code{Author}, \code{Subject}, \code{Keywords}, \code{CreationDate}, and \code{ModDate}.
 \end{document}
 ]]
 

--- a/silex/packages/pdf/init.lua
+++ b/silex/packages/pdf/init.lua
@@ -63,12 +63,10 @@ function package:registerCommands ()
 
         -- Build the content.
         -- Cursor will be moved by the actual definitive size.
-        for _, node in ipairs(box.inner) do
-          node:outputYourself(typesetter, line)
-        end
-
+        box:outputContent(typesetter, line)
         local x1 = typesetter.frame.state.cursorX:tonumber()
         local y1 = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY + box.height):tonumber()
+
         SILE.outputter:endLink(dest, opts, x0, y0, x1, y1) -- Unstable API
       end
     )

--- a/silex/packages/pdf/init.lua
+++ b/silex/packages/pdf/init.lua
@@ -54,32 +54,25 @@ function package:registerCommands ()
       borderwidth = borderwidth,
       borderoffset = borderoffset
     }
-    local x0, y0
-    SILE.typesetter:pushHbox({
-      value = nil,
-      height = 0,
-      width = 0,
-      depth = 0,
-      outputYourself = function (_, typesetter, _)
-        x0 = typesetter.frame.state.cursorX:tonumber()
-        y0 = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY):tonumber()
+
+    SILE.typesetter:liner("pdf:link", content,
+      function (box, typesetter, line)
+        local x0 = typesetter.frame.state.cursorX:tonumber()
+        local y0 = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY):tonumber()
         SILE.outputter:beginLink(dest, opts)
-      end
-    })
-    local hbox, hlist = SILE.typesetter:makeHbox(content) -- hack
-    SILE.typesetter:pushHbox(hbox)
-    SILE.typesetter:pushHbox({
-      value = nil,
-      height = 0,
-      width = 0,
-      depth = 0,
-      outputYourself = function (_, typesetter, _)
+
+        -- Build the content.
+        -- Cursor will be moved by the actual definitive size.
+        for _, node in ipairs(box.inner) do
+          node:outputYourself(typesetter, line)
+        end
+
         local x1 = typesetter.frame.state.cursorX:tonumber()
-        local y1 = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY + hbox.height):tonumber()
+        local y1 = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY + box.height):tonumber()
         SILE.outputter:endLink(dest, opts, x0, y0, x1, y1) -- Unstable API
       end
-    })
-    SILE.typesetter:pushHlist(hlist)
+    )
+
   end)
 
   self:registerCommand("pdf:metadata", function (options, _)

--- a/silex/packages/rules/init.lua
+++ b/silex/packages/rules/init.lua
@@ -1,0 +1,270 @@
+local base = require("packages.base")
+
+local package = pl.class(base)
+package._name = "rules"
+
+local function getUnderlineParameters ()
+  local ot = require("core.opentype-parser")
+  local fontoptions = SILE.font.loadDefaults({})
+  local face = SILE.font.cache(fontoptions, SILE.shaper.getFace)
+  local font = ot.parseFont(face)
+  local upem = font.head.unitsPerEm
+  local underlinePosition = font.post.underlinePosition / upem * fontoptions.size
+  local underlineThickness = font.post.underlineThickness / upem * fontoptions.size
+  return underlinePosition, underlineThickness
+end
+
+local function getStrikethroughParameters ()
+  local ot = require("core.opentype-parser")
+  local fontoptions = SILE.font.loadDefaults({})
+  local face = SILE.font.cache(fontoptions, SILE.shaper.getFace)
+  local font = ot.parseFont(face)
+  local upem = font.head.unitsPerEm
+  local yStrikeoutPosition = font.os2.yStrikeoutPosition / upem * fontoptions.size
+  local yStrikeoutSize = font.os2.yStrikeoutSize / upem * fontoptions.size
+  return yStrikeoutPosition, yStrikeoutSize
+end
+
+-- \hfill (from the "plain" class) and \leaders (from the "leaders" package) use glues,
+-- so we behave the same for hrulefill.
+local hrulefillglue = pl.class(SILE.nodefactory.hfillglue)
+hrulefillglue.raise = SILE.measurement()
+hrulefillglue.thickness = SILE.measurement("0.2pt")
+
+function hrulefillglue:outputYourself (typesetter, line)
+  local outputWidth = SU.rationWidth(self.width, self.width, line.ratio):tonumber()
+  local oldx = typesetter.frame.state.cursorX
+  typesetter.frame:advancePageDirection(-self.raise)
+  typesetter.frame:advanceWritingDirection(outputWidth)
+  local newx = typesetter.frame.state.cursorX
+  local newy = typesetter.frame.state.cursorY
+  SILE.outputter:drawRule(oldx, newy, newx - oldx, self.thickness)
+  typesetter.frame:advancePageDirection(self.raise)
+end
+
+function package:_init ()
+  base._init(self)
+  self:loadPackage("raiselower")
+  self:loadPackage("rebox")
+end
+
+function package:registerCommands ()
+
+  self:registerCommand("hrule", function (options, _)
+    local width = SU.cast("length", options.width)
+    local height = SU.cast("length", options.height)
+    local depth = SU.cast("length", options.depth)
+    SILE.typesetter:pushHbox({
+      width = width:absolute(),
+      height = height:absolute(),
+      depth = depth:absolute(),
+      value = options.src,
+      outputYourself = function (node, typesetter, line)
+        local outputWidth = SU.rationWidth(node.width, node.width, line.ratio)
+        typesetter.frame:advancePageDirection(-node.height)
+        local oldx = typesetter.frame.state.cursorX
+        local oldy = typesetter.frame.state.cursorY
+        typesetter.frame:advanceWritingDirection(outputWidth)
+        typesetter.frame:advancePageDirection(node.height + node.depth)
+        local newx = typesetter.frame.state.cursorX
+        local newy = typesetter.frame.state.cursorY
+        SILE.outputter:drawRule(oldx, oldy, newx - oldx, newy - oldy)
+        typesetter.frame:advancePageDirection(-node.depth)
+      end
+    })
+  end, "Draws a blob of ink of width <width>, height <height> and depth <depth>")
+
+  self:registerCommand("hrulefill", function (options, _)
+    local raise
+    local thickness
+    if options.position and options.raise then
+      SU.error("hrulefill cannot have both position and raise parameters")
+    end
+    if options.thickness then
+      thickness = SU.cast("measurement", options.thickness)
+    end
+    if options.position == "underline" then
+      local underlinePosition, underlineThickness = getUnderlineParameters()
+      thickness = thickness or underlineThickness
+      raise = underlinePosition
+    elseif options.position == "strikethrough" then
+      local yStrikeoutPosition, yStrikeoutSize = getStrikethroughParameters()
+      thickness = thickness or yStrikeoutSize
+      raise = yStrikeoutPosition + thickness / 2
+    elseif options.position then
+      SU.error("Unknown hrulefill position '"..options.position.."'")
+    else
+      raise = SU.cast("measurement", options.raise or "0")
+    end
+
+    SILE.typesetter:pushExplicitGlue(hrulefillglue({
+      raise = raise,
+      thickness = thickness or SILE.measurement("0.2pt"),
+    }))
+  end, "Add a huge horizontal hrule glue")
+
+  self:registerCommand("fullrule", function (options, _)
+    local thickness = SU.cast("measurement", options.thickness or "0.2pt")
+    local raise = SU.cast("measurement", options.raise or "0.5em")
+
+    -- BEGIN DEPRECATION COMPATIBILITY
+    if options.height then
+      SU.deprecated("\\fullrule[…, height=…]", "\\fullrule[…, thickness=…]", "0.13.1", "0.15.0")
+      thickness = SU.cast("measurement", options.height)
+    end
+    if not SILE.typesetter:vmode() then
+      SU.deprecated("\\fullrule in horizontal mode", "\\hrule or \\hrulefill", "0.13.1", "0.15.0")
+      if options.width then
+        SU.deprecated("\\fullrule with width", "\\hrule and \\raise", "0.13.1", "0.15.0")
+        SILE.call("raise", { height = raise }, function ()
+          SILE.call("hrule", {
+            height = thickness,
+            width = options.width
+          })
+        end)
+      else
+        -- This was very broken anyway, as it was overflowing the line.
+        -- At least we try better...
+        SILE.call("hrulefill", { raise = raise, thickness = thickness })
+      end
+     return
+    end
+    if options.width then
+      SU.deprecated("\\fullrule with width", "\\hrule and \\raise", "0.13.1 ", "0.15.0")
+      SILE.call("raise", { height = raise }, function ()
+        SILE.call("hrule", {
+          height = thickness,
+          width = options.width
+        })
+      end)
+    end
+    -- END DEPRECATION COMPATIBILITY
+
+    SILE.typesetter:leaveHmode()
+    SILE.call("noindent")
+    SILE.call("hrulefill", { raise = raise, thickness = thickness })
+    SILE.typesetter:leaveHmode()
+  end, "Draw a full width hrule centered on the current line")
+
+  self:registerCommand("underline", function (_, content)
+    local underlinePosition, underlineThickness = getUnderlineParameters()
+
+    SILE.typesetter:liner("underline", content,
+      function (box, typesetter, line)
+        local oldX = typesetter.frame.state.cursorX
+        local Y = typesetter.frame.state.cursorY
+
+        -- Build the content.
+        -- Cursor will be moved by the actual definitive size.
+        for _, node in ipairs(box.inner) do
+          node:outputYourself(typesetter, line)
+        end
+        local newX = typesetter.frame.state.cursorX
+
+        -- Output a line.
+        -- NOTE: According to the OpenType specs, underlinePosition is "the suggested distance of
+        -- the top of the underline from the baseline" so it seems implied that the thickness
+        -- should expand downwards
+        SILE.outputter:drawRule(oldX, Y - underlinePosition, newX - oldX, underlineThickness)
+      end
+    )
+  end, "Underlines some content")
+
+  self:registerCommand("strikethrough", function (_, content)
+    local yStrikeoutPosition, yStrikeoutSize = getStrikethroughParameters()
+
+    SILE.typesetter:liner("strikethrough", content,
+      function (box, typesetter, line)
+        local oldX = typesetter.frame.state.cursorX
+        local Y = typesetter.frame.state.cursorY
+
+        -- Build the content.
+        -- Cursor will be moved by the actual definitive size.
+        for _, node in ipairs(box.inner) do
+          node:outputYourself(typesetter, line)
+        end
+        local newX = typesetter.frame.state.cursorX
+        -- Output a line.
+        -- NOTE: The OpenType spec is not explicit regarding how the size
+        -- (thickness) affects the position. We opt to distribute evenly
+        SILE.outputter:drawRule(oldX, Y - yStrikeoutPosition - yStrikeoutSize / 2, newX - oldX, yStrikeoutSize)
+      end
+    )
+  end, "Strikes out some content")
+
+  self:registerCommand("boxaround", function (_, content)
+    -- This command was not documented and lacks feature.
+    -- Plan replacement with a better suited package.
+    SU.deprecated("\\boxaround (undocumented)", "\\framebox (package)", "0.12.0")
+
+    local hbox, hlist = SILE.typesetter:makeHbox(content)
+    -- Re-wrap the hbox in another hbox responsible for boxing it at output
+    -- time, when we will know the line contribution and can compute the scaled width
+    -- of the box, taking into account possible stretching and shrinking.
+    SILE.typesetter:pushHbox({
+      inner = hbox,
+      width = hbox.width,
+      height = hbox.height,
+      depth = hbox.depth,
+      outputYourself = function (node, typesetter, line)
+        local oldX = typesetter.frame.state.cursorX
+        local Y = typesetter.frame.state.cursorY
+
+        -- Build the original hbox.
+        -- Cursor will be moved by the actual definitive size.
+        node.inner:outputYourself(SILE.typesetter, line)
+        local newX = typesetter.frame.state.cursorX
+
+        -- Output a border
+        -- NOTE: Drawn inside the hbox, so borders overlap with inner content.
+        local w = newX - oldX
+        local h = node.height:tonumber()
+        local d = node.depth:tonumber()
+        local thickness = 0.5
+
+        SILE.outputter:drawRule(oldX, Y + d - thickness, w, thickness)
+        SILE.outputter:drawRule(oldX, Y - h, w, thickness)
+        SILE.outputter:drawRule(oldX, Y - h, thickness, h + d)
+        SILE.outputter:drawRule(oldX + w - thickness, Y - h, thickness, h + d)
+      end
+    })
+    SILE.typesetter:pushHlist(hlist)
+  end, "Draws a box around some content")
+
+end
+
+package.documentation = [[
+\begin{document}
+The \autodoc:package{rules} package provides several line-drawing commands.
+
+The \autodoc:command{\hrule} command draws a blob of ink of a given \autodoc:parameter{width} (length), \autodoc:parameter{height} (above the current baseline), and \autodoc:parameter{depth} (below the current baseline).
+Such rules are horizontal boxes, placed along the baseline of a line of text and treated just like other text to be output.
+So, they can appear in the middle of a paragraph, like this:
+\hrule[width=20pt, height=0.5pt]
+(That one was generated with \autodoc:command{\hrule[width=20pt, height=0.5pt]}.)
+
+The \autodoc:command{\underline} command \underline{underlines} its content.
+
+The \autodoc:command{\strikethrough} command \strikethrough{strikes} its content.
+
+Both commands support paragraph content spanning multiple lines.
+
+\autodoc:note{The position and thickness of the underlines and strikethroughs are based on the metrics of the current font, honoring the values defined by the type designer.}
+
+The \autodoc:command{\hrulefill} inserts an infinite horizontal rubber, similar to an \autodoc:command{\hfill}, but—as its name implies—filled with a rule (that is, a solid line).
+By default, it stands on the baseline and has a thickness of 0.2pt, below the baseline.
+It supports optional parameters \autodoc:parameter{raise=<dimension>} and \autodoc:parameter{thickness=<dimension>} to adjust the position and thickness of the line, respectively.
+The former accepts a negative measurement, to lower the line.
+Alternatively, use the \autodoc:parameter{position} option, which can be set to \code{underline} or \code{strikethrough}.
+In that case, it honors the current font metrics and the line is drawn at the appropriate position and, by default, with the relevant thickness.
+You can still set a custom thickness with the \autodoc:parameter{thickness} parameter.
+
+For instance, \autodoc:command{\hrulefill[position=underline]} gives:
+\hrulefill[position=underline]
+
+Finally, \autodoc:command{\fullrule} draws a thin standalone rule across the width of a full text line.
+Accepted parameters are \autodoc:parameter{raise} and \autodoc:parameter{thickness}, with the same meanings as above.
+\end{document}
+]]
+
+return package

--- a/silex/packages/rules/init.lua
+++ b/silex/packages/rules/init.lua
@@ -156,9 +156,7 @@ function package:registerCommands ()
 
         -- Build the content.
         -- Cursor will be moved by the actual definitive size.
-        for _, node in ipairs(box.inner) do
-          node:outputYourself(typesetter, line)
-        end
+        box:outputContent(typesetter, line)
         local newX = typesetter.frame.state.cursorX
 
         -- Output a line.
@@ -180,10 +178,9 @@ function package:registerCommands ()
 
         -- Build the content.
         -- Cursor will be moved by the actual definitive size.
-        for _, node in ipairs(box.inner) do
-          node:outputYourself(typesetter, line)
-        end
+        box:outputContent(typesetter, line)
         local newX = typesetter.frame.state.cursorX
+
         -- Output a line.
         -- NOTE: The OpenType spec is not explicit regarding how the size
         -- (thickness) affects the position. We opt to distribute evenly

--- a/silex/typesetters/base.lua
+++ b/silex/typesetters/base.lua
@@ -1014,8 +1014,7 @@ function linerEnterNode:_init(name, outputMethod)
   self.is_enter = true
 end
 function linerEnterNode:clone()
-  local n = linerEnterNode(self.name, self.outputMethod)
-  return n
+  return linerEnterNode(self.name, self.outputMethod)
 end
 function linerEnterNode:outputYourself ()
   SU.error("A liner enter node " .. tostring(self) .. "'' made it to output", true)
@@ -1030,8 +1029,7 @@ function linerLeaveNode:_init(name)
   self.is_leave = true
 end
 function linerLeaveNode:clone()
-  local n = linerLeaveNode(self.name)
-  return n
+  return linerLeaveNode(self.name)
 end
 function linerLeaveNode:outputYourself ()
   SU.error("A liner leave node " .. tostring(self) .. "'' made it to output", true)
@@ -1074,7 +1072,7 @@ end
 -- supposed to be just before meaningful (visible) content.
 ---@param slice   table   Current line nodes
 ---@return boolean        Whether a liner was reopened
-function typesetter:repeatEnterLiners (slice)
+function typesetter:_repeatEnterLiners (slice)
   local m = self.state.liners
   if #m > 0 then
     for i = 1, #m  do
@@ -1091,7 +1089,7 @@ end
 -- Migrating content, however, must be kept outside the hboxes at top slice level.
 ---@param  slice  table   Flat nodes from current line
 ---@return table          New reboxed slice
-function typesetter:reboxLiners (slice)
+function typesetter._reboxLiners (_, slice)
   local outSlice = {}
   local migratingList = {}
   local lboxStack = {}
@@ -1140,7 +1138,7 @@ end
 --- Check if a node is a liner, and process it if so, in a stack.
 ---@param node  any          Current node
 ---@return      boolean      Whether a liner was opened
-function typesetter:processIfLiner(node)
+function typesetter:_processIfLiner(node)
   local entered = false
   if node.is_enter then
     SU.debug("typesetter.liner", "Enter liner", node)
@@ -1161,7 +1159,7 @@ function typesetter:processIfLiner(node)
   return entered
 end
 
-function typesetter:repeatLeaveLiners(slice, insertIndex)
+function typesetter:_repeatLeaveLiners(slice, insertIndex)
   for _, v in ipairs(self.state.liners) do
     if not v.link then
       local n = linerLeaveNode(v.name)
@@ -1222,7 +1220,7 @@ function typesetter:breakpointsToLines (breakpoints)
         if not seenLiner and lastContentNodeIndex then
           -- Any stacked liner (unclosed from a previous line) is reopened on
           -- the current line.
-          seenLiner = self:repeatEnterLiners(slice)
+          seenLiner = self:_repeatEnterLiners(slice)
           lastContentNodeIndex = #slice + 1
         end
         if currentNode.is_discretionary and currentNode.used then
@@ -1235,7 +1233,7 @@ function typesetter:breakpointsToLines (breakpoints)
           if not currentNode.discardable then
             seenNonDiscardable = true
           end
-          seenLiner = self:processIfLiner(currentNode) or seenLiner
+          seenLiner = self:_processIfLiner(currentNode) or seenLiner
         end
       end
       -- END SILEX LINER
@@ -1257,7 +1255,7 @@ function typesetter:breakpointsToLines (breakpoints)
         -- BEGIN SILEX LINER
         -- Any unclosed liner is closed on the next line in reverse order.
         if lastContentNodeIndex then
-          self:repeatLeaveLiners(slice, lastContentNodeIndex + 1)
+          self:_repeatLeaveLiners(slice, lastContentNodeIndex + 1)
         end
         -- END SILEX LINER
 
@@ -1286,7 +1284,7 @@ function typesetter:breakpointsToLines (breakpoints)
         -- BEGIN SILEX LINER
         -- Re-shuffle liners, if any, into their own boxes.
         if seenLiner then
-          slice = self:reboxLiners(slice)
+          slice = self:_reboxLiners(slice)
         end
         -- END SILEX LINER
 


### PR DESCRIPTION
A new approach derived from https://github.com/sile-typesetter/sile/pull/1334

- [x] Cleaner API
- [x] More robust re-boxing logic in standard mode (= paragraphing)
   - [x] Proper migrating content propagation (= footnotes)
   - [x] Correct handling of discretionaries
       - [x] Check for better approach
       - [x] Check that the so-daid "better" approach didn't butcher rskip/lskip margins
- [x] Does not break in horizontal-restricted mode (= inside other horizontal box)
- [x] Use in packages
- [x] Branch on SILE core for regression testing
   - [x] SILE manual fails. Investigate...
- [x] Extra robustness test: check it works as expected in a **parbox** too
- [x]  Extra robustness test: check it works as expected in a **boustrophedon**

**Caveat**: It does further break the broken "pushback" logic (due to additional reboxing)

![image](https://github.com/Omikhleia/silex.sile/assets/18075640/80056ac7-a957-44a7-b60f-0ba2e1e7e7ba)
