### PR TITLE
More compatibility updates for SILE 0.15

### DIFF
--- a/silex/classes/base.lua
+++ b/silex/classes/base.lua
@@ -7,7 +7,6 @@ class.type = "class"
 class._name = "base"
 
 class._initialized = false
-class.deferredLegacyInit = {}
 class.deferredInit = {}
 class.pageTemplate = { frames = {}, firstContentFrame = nil }
 class.defaultFrameset = {}
@@ -73,6 +72,7 @@ function class:_init (options)
 end
 
 function class:_post_init ()
+  SILE.documentState.documentClass = self
   self._initialized = true
   for i, func in ipairs(self.deferredInit) do
     func(self)
@@ -222,13 +222,22 @@ function class:initPackage (pack, options)
   end
 end
 
-function class:registerLegacyPostinit (func, options)
-  if self._initialized then return func(self, options) end
-  table.insert(self.deferredLegacyInit, function (_)
-      func(self, options)
-    end)
-end
-
+--- Register a callback function to be executed after the class initialization has completed.
+-- Sometimes a class or package may want to run things after the class has been fully initialized. This can be useful
+-- for setting document settings after packages and all their dependencies have been loaded. For example a package might
+-- want to trigger something to happen after all frames have been defined, but the package itself doesn't know if it is
+-- being loaded before or after the document options are processed, frame masters have been setup, etc. Rather than
+-- relying on the user to load the package after these events, the package can use this callback to deffer the action
+-- until those things can be reasonable expected to have completed.
+--
+-- Functions in the deferred initialization queue are run on a first-set first-run basis.
+--
+-- Note the typesetter will *not* have been instantiated yet, so is not appropriate to try to output content at this
+-- point. Injecting content to be processed at the start of a document should be done with preambles. The inputter
+-- *will* be instantiated at this point, so adding a new preamble is viable.
+-- If the class has already been initialized the callback function will be run immediately.
+-- @tparam function func Callback function accepting up to two arguments.
+-- @tparam[opt] table options Additional table passed as a second argument to the callback.
 function class:registerPostinit (func, options)
   if self._initialized then return func(self, options) end
   table.insert(self.deferredInit, function (_)

--- a/silex/lang.lua
+++ b/silex/lang.lua
@@ -32,7 +32,7 @@ SILE.X.forLanguage = forLanguage
 
 -- Now we can patch the language support module, hacking the initial implementation
 local icu = require("justenoughicu")
-local loadonce = {}
+SILE.scratch.loaded_languages = {}
 SILE.languageSupport.languages = {}
     -- BEGIN OMIKHLEIA HACKLANG
     -- BAD CODE SMELL WARNING
@@ -60,8 +60,8 @@ SILE.languageSupport.loadLanguage = function (language)
     end
     -- END OMIKHLEIA HACKLANG
 
-    if loadonce[language] then return end
-    loadonce[language] = true
+    if SILE.scratch.loaded_languages[language] then return end
+    SILE.scratch.loaded_languages[language] = true
 
     -- BEGIN OMIKHLEIA HACKLANG
     -- We need to find language resources for this BCP47 identifier, from the less specific


### PR DESCRIPTION
See #11 

Some other overlooked changes (0.15.5 PR 2095) and language-related logic (0.15.4 PR 2062).

(The former was breaking the resilient collection, the later kept generating warnings on valid use cases)