### PR TITLE
chore(classes,packages): Styling and small updates from SILE 0.15.9

### DIFF
--- a/silex/classes/base.lua
+++ b/silex/classes/base.lua
@@ -1,7 +1,8 @@
---- SILE base document class.
+--- SILE document class interface.
+-- @interfaces classes
 --
 -- WARNING: With sile·x modifications
---
+
 local class = pl.class()
 class.type = "class"
 class._name = "base"
@@ -12,214 +13,224 @@ class.pageTemplate = { frames = {}, firstContentFrame = nil }
 class.defaultFrameset = {}
 class.firstContentFrame = "page"
 class.options = setmetatable({}, {
-    _opts = {},
-    __newindex = function (self, key, value)
+   _opts = {},
+   __newindex = function (self, key, value)
       local opts = getmetatable(self)._opts
       if type(opts[key]) == "function" then
-        opts[key](class, value)
+         opts[key](class, value)
       elseif type(value) == "function" then
-        opts[key] = value
+         opts[key] = value
       elseif type(key) == "number" then
-        return nil
+         return nil
       else
-        SU.error("Attempted to set an undeclared class option '" .. key .. "'")
+         SU.error("Attempted to set an undeclared class option '" .. key .. "'")
       end
-    end,
-    __index = function (self, key)
-      if key == "super" then return nil end
-      if type(key) == "number" then return nil end
+   end,
+   __index = function (self, key)
+      if key == "super" then
+         return nil
+      end
+      if type(key) == "number" then
+         return nil
+      end
       local opt = getmetatable(self)._opts[key]
       if type(opt) == "function" then
-        return opt(class)
+         return opt(class)
       elseif opt then
-        return opt
+         return opt
       else
-        SU.error("Attempted to get an undeclared class option '" .. key .. "'")
+         SU.error("Attempted to get an undeclared class option '" .. key .. "'")
       end
-    end
-  })
+   end,
+})
 class.hooks = {
-  newpage = {},
-  endpage = {},
-  finish = {},
+   newpage = {},
+   endpage = {},
+   finish = {},
 }
 
 class.packages = {}
 
 function class:_init (options)
-  SILE.scratch.half_initialized_class = self
-  if self == options then options = {} end
-  SILE.languageSupport.loadLanguage('und') -- preload for unlocalized fallbacks
-  self:declareOptions()
-  self:registerRawHandlers()
-  self:declareSettings()
-  self:registerCommands()
-  self:setOptions(options)
-  self:declareFrames(self.defaultFrameset)
-  self:registerPostinit(function (self_)
+   SILE.scratch.half_initialized_class = self
+   if self == options then
+      options = {}
+   end
+   SILE.languageSupport.loadLanguage("und") -- preload for unlocalized fallbacks
+   self:declareOptions()
+   self:registerRawHandlers()
+   self:declareSettings()
+   self:registerCommands()
+   self:setOptions(options)
+   self:declareFrames(self.defaultFrameset)
+   self:registerPostinit(function (self_)
       if type(self.firstContentFrame) == "string" then
-        self_.pageTemplate.firstContentFrame = self_.pageTemplate.frames[self_.firstContentFrame]
+         self_.pageTemplate.firstContentFrame = self_.pageTemplate.frames[self_.firstContentFrame]
       end
       local frame = self_:initialFrame()
       SILE.typesetter = SILE.typesetters.base(frame)
       SILE.typesetter:registerPageEndHook(function ()
-        SU.debug("frames", function ()
-          for _, v in pairs(SILE.frames) do SILE.outputter:debugFrame(v) end
-          return "Drew debug outlines around frames"
-        end)
+         SU.debug("frames", function ()
+            for _, v in pairs(SILE.frames) do
+               SILE.outputter:debugFrame(v)
+            end
+            return "Drew debug outlines around frames"
+         end)
       end)
-    end)
+   end)
 end
 
 function class:_post_init ()
-  SILE.documentState.documentClass = self
-  self._initialized = true
-  for i, func in ipairs(self.deferredInit) do
-    func(self)
-    self.deferredInit[i] = nil
-  end
-  SILE.scratch.half_initialized_class = nil
+   SILE.documentState.documentClass = self
+   self._initialized = true
+   for i, func in ipairs(self.deferredInit) do
+      func(self)
+      self.deferredInit[i] = nil
+   end
+   SILE.scratch.half_initialized_class = nil
 end
 
 function class:setOptions (options)
-  options = options or {}
-  options.papersize = options.papersize or "a4"
-  -- BEGIN SILEX FULL BLEED AND PAGE SIZE
-  options.bleed = options.bleed or "0"
-  -- END SILEX FULL BLEED AND PAGE SIZE
-  for option, value in pairs(options) do
-    self.options[option] = value
-  end
-
-  -- BEGIN SILEX FULL BLEED AND PAGE SIZE
-  if not SILE.documentState.sheetSize then
-    SILE.documentState.sheetSize = {
-      SILE.documentState.paperSize[1],
-      SILE.documentState.paperSize[2]
-    }
-  end
-  if SILE.documentState.sheetSize[1] < SILE.documentState.paperSize[1]
-      or SILE.documentState.sheetSize[2] < SILE.documentState.paperSize[2] then
-    SU.error("Sheet size shall not be smaller than the paper size")
-  end
-  if SILE.documentState.sheetSize[1] < SILE.documentState.paperSize[1] + SILE.documentState.bleed then
-    SU.debug("frames", "Sheet size width augmented to take page bleed into account")
-    SILE.documentState.sheetSize[1] = SILE.documentState.paperSize[1] + SILE.documentState.bleed
-  end
-  if SILE.documentState.sheetSize[2] < SILE.documentState.paperSize[2] + SILE.documentState.bleed then
-    SU.debug("frames", "Sheet size height augmented to take page bleed into account")
-    SILE.documentState.sheetSize[2] = SILE.documentState.paperSize[2] + SILE.documentState.bleed
-  end
-  -- END SILEX FULL BLEED AND PAGE SIZE
+   options = options or {}
+   options.papersize = options.papersize or "a4"
+   options.bleed = options.bleed or "0"
+   for option, value in pairs(options) do
+      self.options[option] = value
+   end
+   if not SILE.documentState.sheetSize then
+      SILE.documentState.sheetSize = {
+         SILE.documentState.paperSize[1],
+         SILE.documentState.paperSize[2]
+      }
+   end
+   if SILE.documentState.sheetSize[1] < SILE.documentState.paperSize[1]
+         or SILE.documentState.sheetSize[2] < SILE.documentState.paperSize[2] then
+      SU.error("Sheet size shall not be smaller than the paper size")
+   end
+   if SILE.documentState.sheetSize[1] < SILE.documentState.paperSize[1] + SILE.documentState.bleed then
+      SU.debug("frames", "Sheet size width augmented to take page bleed into account")
+      SILE.documentState.sheetSize[1] = SILE.documentState.paperSize[1] + SILE.documentState.bleed
+   end
+   if SILE.documentState.sheetSize[2] < SILE.documentState.paperSize[2] + SILE.documentState.bleed then
+      SU.debug("frames", "Sheet size height augmented to take page bleed into account")
+      SILE.documentState.sheetSize[2] = SILE.documentState.paperSize[2] + SILE.documentState.bleed
+   end
 end
 
 function class:declareOption (option, setter)
-  rawset(getmetatable(self.options)._opts, option, nil)
-  self.options[option] = setter
+   rawset(getmetatable(self.options)._opts, option, nil)
+   self.options[option] = setter
 end
 
 function class:declareOptions ()
-  self:declareOption("class", function (_, name)
-    if name then
-      if self._legacy then
-        self._name = name
-      elseif name ~= self._name then
-        SU.error("Cannot change class name after instantiation, derive a new class instead.")
+   self:declareOption("class", function (_, name)
+      if name then
+         if self._legacy then
+            self._name = name
+         elseif name ~= self._name then
+            SU.error("Cannot change class name after instantiation, derive a new class instead")
+         end
       end
-    end
-    return self._name
-  end)
-  self:declareOption("papersize", function (_, size)
-    if size then
-      self.papersize = size
-      SILE.documentState.paperSize = SILE.papersize(size)
-      SILE.documentState.orgPaperSize = SILE.documentState.paperSize
-      SILE.newFrame({
-        id = "page",
-        left = 0,
-        top = 0,
-        right = SILE.documentState.paperSize[1],
-        bottom = SILE.documentState.paperSize[2]
-      })
-    end
-    return self.papersize
-  end)
-  -- BEGIN SILEX FULL BLEED AND PAGE SIZE
-  self:declareOption("sheetsize", function (_, size)
-    if size then
-      self.sheetsize = size
-      SILE.documentState.sheetSize = SILE.papersize(size)
-    end
-    return self.sheetsize
-  end)
-  self:declareOption("bleed", function (_, dimen)
-    if dimen then
-      self.bleed = dimen
-      SILE.documentState.bleed = SU.cast("measurement", dimen):tonumber()
-    end
-    return self.bleed
-  end)
-  -- END SILEX FULL BLEED AND PAGE SIZE
+      return self._name
+   end)
+   self:declareOption("papersize", function (_, size)
+      if size then
+         self.papersize = size
+         SILE.documentState.paperSize = SILE.papersize(size)
+         SILE.documentState.orgPaperSize = SILE.documentState.paperSize
+         SILE.newFrame({
+            id = "page",
+            left = 0,
+            top = 0,
+            right = SILE.documentState.paperSize[1],
+            bottom = SILE.documentState.paperSize[2],
+         })
+      end
+      return self.papersize
+   end)
+   self:declareOption("sheetsize", function (_, size)
+      if size then
+         self.sheetsize = size
+         SILE.documentState.sheetSize = SILE.papersize(size)
+      end
+      return self.sheetsize
+   end)
+   self:declareOption("bleed", function (_, dimen)
+      if dimen then
+         self.bleed = dimen
+         SILE.documentState.bleed = SU.cast("measurement", dimen):tonumber()
+      end
+      return self.bleed
+   end)
 end
 
 function class.declareSettings (_)
-  SILE.settings:declare({
-    parameter = "current.parindent",
-    type = "glue or nil",
-    default = nil,
-    help = "Glue at start of paragraph"
-  })
-  SILE.settings:declare({
-    parameter = "current.hangIndent",
-    type = "measurement or nil",
-    default = nil,
-    help = "Size of hanging indent"
-  })
-  SILE.settings:declare({
-    parameter = "current.hangAfter",
-    type = "integer or nil",
-    default = nil,
-    help = "Number of lines affected by handIndent"
-  })
+   SILE.settings:declare({
+      parameter = "current.parindent",
+      type = "glue or nil",
+      default = nil,
+      help = "Glue at start of paragraph",
+   })
+   SILE.settings:declare({
+      parameter = "current.hangIndent",
+      type = "measurement or nil",
+      default = nil,
+      help = "Size of hanging indent",
+   })
+   SILE.settings:declare({
+      parameter = "current.hangAfter",
+      type = "integer or nil",
+      default = nil,
+      help = "Number of lines affected by handIndent",
+   })
 end
 
 function class:loadPackage (packname, options)
-  local pack = require(("packages.%s"):format(packname))
-  if type(pack) == "table" and pack.type == "package" then -- new package
-    -- BEGIN SILEX CANCEL MULTIPLE PACKAGE INSTANCIATION
-    -- I beg to disagree with SILE here.
-    if self.packages[pack._name] then
-      return SU.debug("silex", "Ignoring package already loaded in the class:", pack._name)
-    end
-    -- END SILEX CANCEL MULTIPLE PACKAGE INSTANCIATION
-    self.packages[pack._name] = pack(options)
-  else -- legacy package
-    SU.warn("CLASS: legacy package "..pack._name)
-    self:initPackage(pack, options)
-  end
+   local pack = require(("packages.%s"):format(packname))
+   if type(pack) == "table" and pack.type == "package" then -- new package
+      -- BEGIN SILEX CANCEL MULTIPLE PACKAGE INSTANCIATION
+      -- I beg to disagree with SILE here.
+      if self.packages[pack._name] then
+         return SU.debug("silex", "Ignoring package already loaded in the class:", pack._name)
+      end
+      -- END SILEX CANCEL MULTIPLE PACKAGE INSTANCIATION
+      self.packages[pack._name] = pack(options)
+   else -- legacy package
+      SU.warn("CLASS: legacy package "..pack._name)
+      self:initPackage(pack, options)
+   end
 end
 
 function class:initPackage (pack, options)
-  SU.deprecated("class:initPackage(options)", "package(options)", "0.14.0", "0.16.0", [[
-  This package appears to be a legacy format package. It returns a table
-  an expects SILE to guess a bit about what to do. New packages inherit
-  from the base class and have a constructor function (_init) that
-  automatically handles setup.]])
-  if type(pack) == "table" then
-    if pack.exports then pl.tablex.update(self, pack.exports) end
-    if type(pack.declareSettings) == "function" then
-      pack.declareSettings(self)
-    end
-    if type(pack.registerRawHandlers) == "function" then
-      pack.registerRawHandlers(self)
-    end
-    if type(pack.registerCommands) == "function" then
-      pack.registerCommands(self)
-    end
-    if type(pack.init) == "function" then
-      self:registerPostinit(pack.init, options)
-    end
-  end
+   SU.deprecated(
+      "class:initPackage(options)",
+      "package(options)",
+      "0.14.0",
+      "0.16.0",
+      [[
+         This package appears to be a legacy format package. It returns a table and
+         expects SILE to guess about what to do. New packages inherit from the base
+         class and have a constructor function (_init) that automatically handles
+         setup.
+      ]]
+   )
+   if type(pack) == "table" then
+      if pack.exports then
+         pl.tablex.update(self, pack.exports)
+      end
+      if type(pack.declareSettings) == "function" then
+         pack.declareSettings(self)
+      end
+      if type(pack.registerRawHandlers) == "function" then
+         pack.registerRawHandlers(self)
+      end
+      if type(pack.registerCommands) == "function" then
+         pack.registerCommands(self)
+      end
+      if type(pack.init) == "function" then
+         self:registerPostinit(pack.init, options)
+      end
+   end
 end
 
 --- Register a callback function to be executed after the class initialization has completed.
@@ -227,7 +238,7 @@ end
 -- for setting document settings after packages and all their dependencies have been loaded. For example a package might
 -- want to trigger something to happen after all frames have been defined, but the package itself doesn't know if it is
 -- being loaded before or after the document options are processed, frame masters have been setup, etc. Rather than
--- relying on the user to load the package after these events, the package can use this callback to deffer the action
+-- relying on the user to load the package after these events, the package can use this callback to defer the action
 -- until those things can be reasonable expected to have completed.
 --
 -- Functions in the deferred initialization queue are run on a first-set first-run basis.
@@ -239,397 +250,432 @@ end
 -- @tparam function func Callback function accepting up to two arguments.
 -- @tparam[opt] table options Additional table passed as a second argument to the callback.
 function class:registerPostinit (func, options)
-  if self._initialized then return func(self, options) end
-  table.insert(self.deferredInit, function (_)
+   if self._initialized then
+      return func(self, options)
+   end
+   table.insert(self.deferredInit, function (_)
       func(self, options)
-    end)
+   end)
 end
 
 function class:registerHook (category, func)
-  for _, func_ in ipairs(self.hooks[category]) do
-    if func_ == func then
-      return
-      --[[ See https://github.com/sile-typesetter/sile/issues/1531
+   for _, func_ in ipairs(self.hooks[category]) do
+      if func_ == func then
+         return
+         --[[ See https://github.com/sile-typesetter/sile/issues/1531
       return SU.warn("Attempted to set the same function hook twice, probably unintended, skipping.")
       -- If the same function signature is already set a package is probably being
       -- re-initialized. Ditch the first instance of the hook so that it runs in
       -- the order of last initialization.
       self.hooks[category][_] = nil
       ]]
-    end
-  end
-  table.insert(self.hooks[category], func)
+      end
+   end
+   table.insert(self.hooks[category], func)
 end
 
 function class:runHooks (category, options)
-  for _, func in ipairs(self.hooks[category]) do
-    SU.debug("classhooks", "Running hook from", category, options and "with options " .. #options)
-    func(self, options)
-  end
+   for _, func in ipairs(self.hooks[category]) do
+      SU.debug("classhooks", "Running hook from", category, options and "with options #" .. #options)
+      func(self, options)
+   end
 end
 
+--- Register a function as a SILE command.
+-- Takes any Lua function and registers it for use as a SILE command (which will in turn be used to process any content
+-- nodes identified with the command name.
+--
+-- Note that this should only be used to register commands supplied directly by a document class. A similar method is
+-- available for packages, `packages:registerCommand`.
+-- @tparam string name Name of cammand to register.
+-- @tparam function func Callback function to use as command handler.
+-- @tparam[opt] nil|string help User friendly short usage string for use in error messages, documentation, etc.
+-- @tparam[opt] nil|string pack Information identifying the module registering the command for use in error and usage
+-- messages. Usually auto-detected.
+-- @see SILE.packages:registerCommand
 function class.registerCommand (_, name, func, help, pack)
-  SILE.Commands[name] = func
-  if not pack then
-    local where = debug.getinfo(2).source
-    pack = where:match("(%w+).lua")
-  end
-  --if not help and not pack:match(".sil") then SU.error("Could not define command '"..name.."' (in package "..pack..") - no help text" ) end
-  SILE.Help[name] = {
-    description = help,
-    where = pack
-  }
+   SILE.Commands[name] = func
+   if not pack then
+      local where = debug.getinfo(2).source
+      pack = where:match("(%w+).lua")
+   end
+   --if not help and not pack:match(".sil") then SU.error("Could not define command '"..name.."' (in package "..pack..") - no help text" ) end
+   SILE.Help[name] = {
+      description = help,
+      where = pack,
+   }
 end
 
 function class.registerRawHandler (_, format, callback)
-  SILE.rawHandlers[format] = callback
+   SILE.rawHandlers[format] = callback
 end
 
 function class:registerRawHandlers ()
-
-  self:registerRawHandler("text", function (_, content)
-    SILE.settings:temporarily(function()
-      SILE.settings:set("typesetter.parseppattern", "\n")
-      SILE.settings:set("typesetter.obeyspaces", true)
-      SILE.typesetter:typeset(content[1])
-    end)
-  end)
-
+   self:registerRawHandler("text", function (_, content)
+      SILE.settings:temporarily(function ()
+         SILE.settings:set("typesetter.parseppattern", "\n")
+         SILE.settings:set("typesetter.obeyspaces", true)
+         SILE.typesetter:typeset(content[1])
+      end)
+   end)
 end
 
 local function packOptions (options)
-  local relevant = pl.tablex.copy(options)
-  relevant.src = nil
-  relevant.format = nil
-  relevant.module = nil
-  relevant.require = nil
-  return relevant
+   local relevant = pl.tablex.copy(options)
+   relevant.src = nil
+   relevant.format = nil
+   relevant.module = nil
+   relevant.require = nil
+   return relevant
 end
 
 function class:registerCommands ()
-
-  local function replaceProcessBy(replacement, tree)
-    if type(tree) ~= "table" then return tree end
-    local ret = pl.tablex.deepcopy(tree)
-    if tree.command == "process" then
-      return replacement
-    else
-      for i, child in ipairs(tree) do
-        ret[i] = replaceProcessBy(replacement, child)
+   local function replaceProcessBy (replacement, tree)
+      if type(tree) ~= "table" then
+         return tree
       end
-      return ret
-    end
-  end
-
-  self:registerCommand("define", function (options, content)
-    SU.required(options, "command", "defining command")
-    if type(content) == "function" then
-      -- A macro defined as a function can take no argument, so we register
-      -- it as-is.
-      self:registerCommand(options["command"], content)
-      return
-    elseif options.command == "process" then
-      SU.warn("Did you mean to re-definine the `\\process` macro? That probably won't go well.")
-    end
-    self:registerCommand(options["command"], function (_, inner_content)
-      SU.debug("macros", "Processing macro \\" .. options["command"])
-      local macroArg
-      if type(inner_content) == "function" then
-        macroArg = inner_content
-      elseif type(inner_content) == "table" then
-        macroArg = pl.tablex.copy(inner_content)
-        macroArg.command = nil
-        macroArg.id = nil
-      elseif inner_content == nil then
-        macroArg = {}
+      local ret = pl.tablex.deepcopy(tree)
+      if tree.command == "process" then
+         return replacement
       else
-        SU.error("Unhandled content type " .. type(inner_content) .. " passed to macro \\" .. options["command"], true)
+         for i, child in ipairs(tree) do
+            ret[i] = replaceProcessBy(replacement, child)
+         end
+         return ret
       end
-      -- Replace every occurrence of \process in `content` (the macro
-      -- body) with `macroArg`, then have SILE go through the new `content`.
-      local newContent = replaceProcessBy(macroArg, content)
-      SILE.process(newContent)
-      SU.debug("macros", "Finished processing \\" .. options["command"])
-    end, options.help, SILE.currentlyProcessingFile)
-  end, "Define a new macro. \\define[command=example]{ ... \\process }")
+   end
 
-  -- A utility function that allows SILE.call() to be used as a noop wrapper.
-  self:registerCommand("noop", function (_, content)
-    SILE.process(content)
-  end)
+   self:registerCommand("define", function (options, content)
+      SU.required(options, "command", "defining command")
+      if type(content) == "function" then
+         -- A macro defined as a function can take no argument, so we register
+         -- it as-is.
+         self:registerCommand(options["command"], content)
+         return
+      elseif options.command == "process" then
+         SU.warn([[
+            Did you mean to re-definine the `\\process` macro?
 
-  -- The document (SIL) or sile (XML) command is always the sigular leaf at the
-  -- top level of our AST. The work you might expect to see happen here is
-  -- actually handled by SILE.inputter:classInit() before we get here, so these
-  -- are just pass through functions. Theoretically, this could be a useful
-  -- point to hook into-especially for included documents.
-  self:registerCommand("document", function (_, content)
-    SILE.process(content)
-  end)
-  self:registerCommand("sile", function (_, content)
-    SILE.process(content)
-  end)
+            That probably won't go well.
+         ]])
+      end
+      self:registerCommand(options["command"], function (_, inner_content)
+         SU.debug("macros", "Processing macro \\" .. options["command"])
+         local macroArg
+         if type(inner_content) == "function" then
+            macroArg = inner_content
+         elseif type(inner_content) == "table" then
+            macroArg = pl.tablex.copy(inner_content)
+            macroArg.command = nil
+            macroArg.id = nil
+         elseif inner_content == nil then
+            macroArg = {}
+         else
+            SU.error(
+               "Unhandled content type " .. type(inner_content) .. " passed to macro \\" .. options["command"],
+               true
+            )
+         end
+         -- Replace every occurrence of \process in `content` (the macro
+         -- body) with `macroArg`, then have SILE go through the new `content`.
+         local newContent = replaceProcessBy(macroArg, content)
+         SILE.process(newContent)
+         SU.debug("macros", "Finished processing \\" .. options["command"])
+      end, options.help, SILE.currentlyProcessingFile)
+   end, "Define a new macro. \\define[command=example]{ ... \\process }")
 
-  self:registerCommand("comment", function (_, _)
-  end, "Ignores any text within this command's body.")
+   -- A utility function that allows SILE.call() to be used as a noop wrapper.
+   self:registerCommand("noop", function (_, content)
+      SILE.process(content)
+   end)
 
-  self:registerCommand("process", function ()
-    SU.error("Encountered unsubstituted \\process.")
-  end, "Within a macro definition, processes the contents of the macro body.")
+   -- The document (SIL) or sile (XML) command is always the sigular leaf at the
+   -- top level of our AST. The work you might expect to see happen here is
+   -- actually handled by SILE.inputter:classInit() before we get here, so these
+   -- are just pass through functions. Theoretically, this could be a useful
+   -- point to hook into-especially for included documents.
+   self:registerCommand("document", function (_, content)
+      SILE.process(content)
+   end)
+   self:registerCommand("sile", function (_, content)
+      SILE.process(content)
+   end)
 
-  self:registerCommand("script", function (options, content)
-    local packopts = packOptions(options)
-    if SU.ast.hasContent(content) then
-      return SILE.processString(content[1], options.format or "lua", nil, packopts)
-    elseif options.src then
-      return SILE.require(options.src)
-    else
-      SU.error("\\script function requires inline content or a src file path")
-      return SILE.processString(content[1], options.format or "lua", nil, packopts)
-    end
-  end, "Runs lua code. The code may be supplied either inline or using src=...")
+   self:registerCommand("comment", function (_, _) end, "Ignores any text within this command's body.")
 
-  self:registerCommand("include", function (options, content)
-    local packopts = packOptions(options)
-    if SU.ast.hasContent(content) then
-      local doc = SU.ast.contentToString(content)
-      return SILE.processString(doc, options.format, nil, packopts)
-    elseif options.src then
-      return SILE.processFile(options.src, options.format, packopts)
-    else
-      SU.error("\\include function requires inline content or a src file path")
-    end
-  end, "Includes a content file for processing.")
+   self:registerCommand("process", function ()
+      SU.error("Encountered unsubstituted \\process")
+   end, "Within a macro definition, processes the contents of the macro body.")
 
-  self:registerCommand("lua", function (options, content)
-    local packopts = packOptions(options)
-    if SU.ast.hasContent(content) then
-      local doc = SU.ast.contentToString(content)
-      return SILE.processString(doc, "lua", nil, packopts)
-    elseif options.src then
-      return SILE.processFile(options.src, "lua", packopts)
-    elseif options.require then
-      local module = SU.required(options, "require", "lua")
-      return require(module)
-    else
-      SU.error("\\lua function requires inline content or a src file path or a require module name")
-    end
-  end, "Run Lua code. The code may be supplied either inline, using require=... for a Lua module, or using src=... for a file path")
-
-  self:registerCommand("sil", function (options, content)
-    local packopts = packOptions(options)
-    if SU.ast.hasContent(content) then
-      local doc = SU.ast.contentToString(content)
-      return SILE.processString(doc, "sil")
-    elseif options.src then
-      return SILE.processFile(options.src, "sil", packopts)
-    else
-      SU.error("\\sil function requires inline content or a src file path")
-    end
-  end, "Process sil content. The content may be supplied either inline or using src=...")
-
-  self:registerCommand("xml", function (options, content)
-    local packopts = packOptions(options)
-    if SU.ast.hasContent(content) then
-      local doc = SU.ast.contentToString(content)
-      return SILE.processString(doc, "xml", nil, packopts)
-    elseif options.src then
-      return SILE.processFile(options.src, "xml", packopts)
-    else
-      SU.error("\\xml function requires inline content or a src file path")
-    end
-  end, "Process xml content. The content may be supplied either inline or using src=...")
-
-  self:registerCommand("use", function (options, content)
-    local packopts = packOptions(options)
-    if content[1] and string.len(content[1]) > 0 then
-      local doc = SU.ast.contentToString(content)
-      SILE.processString(doc, "lua", nil, packopts)
-    else
-      if options.src then
-        SU.warn("Use of 'src' with \\use is discouraged because some of it's path handling\n  will eventually be deprecated. Use 'module' instead when possible.")
-        SILE.processFile(options.src, "lua", packopts)
+   self:registerCommand("script", function (options, content)
+      local packopts = packOptions(options)
+      if SU.ast.hasContent(content) then
+         return SILE.processString(content[1], options.format or "lua", nil, packopts)
+      elseif options.src then
+         return SILE.require(options.src)
       else
-        local module = SU.required(options, "module", "use")
-        SILE.use(module, packopts)
+         SU.error("\\script function requires inline content or a src file path")
+         return SILE.processString(content[1], options.format or "lua", nil, packopts)
       end
-    end
-  end, "Load and initialize a SILE module (can be a package, a shaper, a typesetter, or whatever). Use module=... to specif what to load or include module code inline.")
+   end, "Runs lua code. The code may be supplied either inline or using src=...")
 
-  self:registerCommand("raw", function (options, content)
-    local rawtype = SU.required(options, "type", "raw")
-    local handler = SILE.rawHandlers[rawtype]
-    if not handler then SU.error("No inline handler for '"..rawtype.."'") end
-    handler(options, content)
-  end, "Invoke a raw passthrough handler")
+   self:registerCommand("include", function (options, content)
+      local packopts = packOptions(options)
+      if SU.ast.hasContent(content) then
+         local doc = SU.ast.contentToString(content)
+         return SILE.processString(doc, options.format, nil, packopts)
+      elseif options.src then
+         return SILE.processFile(options.src, options.format, packopts)
+      else
+         SU.error("\\include function requires inline content or a src file path")
+      end
+   end, "Includes a content file for processing.")
 
-  self:registerCommand("pagetemplate", function (options, content)
-    SILE.typesetter:pushState()
-    SILE.documentState.thisPageTemplate = { frames = {} }
-    SILE.process(content)
-    SILE.documentState.thisPageTemplate.firstContentFrame = SILE.getFrame(options["first-content-frame"])
-    SILE.typesetter:initFrame(SILE.documentState.thisPageTemplate.firstContentFrame)
-    SILE.typesetter:popState()
-  end, "Defines a new page template for the current page and sets the typesetter to use it.")
+   self:registerCommand(
+      "lua",
+      function (options, content)
+         local packopts = packOptions(options)
+         if SU.ast.hasContent(content) then
+            local doc = SU.ast.contentToString(content)
+            return SILE.processString(doc, "lua", nil, packopts)
+         elseif options.src then
+            return SILE.processFile(options.src, "lua", packopts)
+         elseif options.require then
+            local module = SU.required(options, "require", "lua")
+            return require(module)
+         else
+            SU.error("\\lua function requires inline content or a src file path or a require module name")
+         end
+      end,
+      "Run Lua code. The code may be supplied either inline, using require=... for a Lua module, or using src=... for a file path"
+   )
 
-  self:registerCommand("frame", function (options, _)
-    SILE.documentState.thisPageTemplate.frames[options.id] = SILE.newFrame(options)
-  end, "Declares (or re-declares) a frame on this page.")
+   self:registerCommand("sil", function (options, content)
+      local packopts = packOptions(options)
+      if SU.ast.hasContent(content) then
+         local doc = SU.ast.contentToString(content)
+         return SILE.processString(doc, "sil")
+      elseif options.src then
+         return SILE.processFile(options.src, "sil", packopts)
+      else
+         SU.error("\\sil function requires inline content or a src file path")
+      end
+   end, "Process sil content. The content may be supplied either inline or using src=...")
 
-  self:registerCommand("penalty", function (options, _)
-    if SU.boolean(options.vertical, false) and not SILE.typesetter:vmode() then
+   self:registerCommand("xml", function (options, content)
+      local packopts = packOptions(options)
+      if SU.ast.hasContent(content) then
+         local doc = SU.ast.contentToString(content)
+         return SILE.processString(doc, "xml", nil, packopts)
+      elseif options.src then
+         return SILE.processFile(options.src, "xml", packopts)
+      else
+         SU.error("\\xml function requires inline content or a src file path")
+      end
+   end, "Process xml content. The content may be supplied either inline or using src=...")
+
+   self:registerCommand(
+      "use",
+      function (options, content)
+         local packopts = packOptions(options)
+         if content[1] and string.len(content[1]) > 0 then
+            local doc = SU.ast.contentToString(content)
+            SILE.processString(doc, "lua", nil, packopts)
+         else
+            if options.src then
+               SU.warn([[
+                  Use of 'src' with \\use is discouraged.
+
+                  Its path handling  will eventually be deprecated.
+                  Use 'module' instead when possible.
+               ]])
+               SILE.processFile(options.src, "lua", packopts)
+            else
+               local module = SU.required(options, "module", "use")
+               SILE.use(module, packopts)
+            end
+         end
+      end,
+      "Load and initialize a SILE module (can be a package, a shaper, a typesetter, or whatever). Use module=... to specif what to load or include module code inline."
+   )
+
+   self:registerCommand("raw", function (options, content)
+      local rawtype = SU.required(options, "type", "raw")
+      local handler = SILE.rawHandlers[rawtype]
+      if not handler then
+         SU.error("No inline handler for '" .. rawtype .. "'")
+      end
+      handler(options, content)
+   end, "Invoke a raw passthrough handler")
+
+   self:registerCommand("pagetemplate", function (options, content)
+      SILE.typesetter:pushState()
+      SILE.documentState.thisPageTemplate = { frames = {} }
+      SILE.process(content)
+      SILE.documentState.thisPageTemplate.firstContentFrame = SILE.getFrame(options["first-content-frame"])
+      SILE.typesetter:initFrame(SILE.documentState.thisPageTemplate.firstContentFrame)
+      SILE.typesetter:popState()
+   end, "Defines a new page template for the current page and sets the typesetter to use it.")
+
+   self:registerCommand("frame", function (options, _)
+      SILE.documentState.thisPageTemplate.frames[options.id] = SILE.newFrame(options)
+   end, "Declares (or re-declares) a frame on this page.")
+
+   self:registerCommand("penalty", function (options, _)
+      if SU.boolean(options.vertical, false) and not SILE.typesetter:vmode() then
+         SILE.typesetter:leaveHmode()
+      end
+      if SILE.typesetter:vmode() then
+         SILE.typesetter:pushVpenalty({ penalty = tonumber(options.penalty) })
+      else
+         SILE.typesetter:pushPenalty({ penalty = tonumber(options.penalty) })
+      end
+   end, "Inserts a penalty node. Option is penalty= for the size of the penalty.")
+
+   self:registerCommand("discretionary", function (options, _)
+      local discretionary = SILE.types.node.discretionary({})
+      if options.prebreak then
+         local hbox = SILE.typesetter:makeHbox({ options.prebreak })
+         discretionary.prebreak = { hbox }
+      end
+      if options.postbreak then
+         local hbox = SILE.typesetter:makeHbox({ options.postbreak })
+         discretionary.postbreak = { hbox }
+      end
+      if options.replacement then
+         local hbox = SILE.typesetter:makeHbox({ options.replacement })
+         discretionary.replacement = { hbox }
+      end
+      table.insert(SILE.typesetter.state.nodes, discretionary)
+   end, "Inserts a discretionary node.")
+
+   self:registerCommand("glue", function (options, _)
+      local width = SU.cast("length", options.width):absolute()
+      SILE.typesetter:pushGlue(width)
+   end, "Inserts a glue node. The width option denotes the glue dimension.")
+
+   self:registerCommand("kern", function (options, _)
+      local width = SU.cast("length", options.width):absolute()
+      SILE.typesetter:pushHorizontal(SILE.types.node.kern(width))
+   end, "Inserts a glue node. The width option denotes the glue dimension.")
+
+   self:registerCommand("skip", function (options, _)
+      options.discardable = SU.boolean(options.discardable, false)
+      options.height = SILE.types.length(options.height):absolute()
       SILE.typesetter:leaveHmode()
-    end
-    if SILE.typesetter:vmode() then
-      SILE.typesetter:pushVpenalty({ penalty = tonumber(options.penalty) })
-    else
-      SILE.typesetter:pushPenalty({ penalty = tonumber(options.penalty) })
-    end
-  end, "Inserts a penalty node. Option is penalty= for the size of the penalty.")
+      if options.discardable then
+         SILE.typesetter:pushVglue(options)
+      else
+         SILE.typesetter:pushExplicitVglue(options)
+      end
+   end, "Inserts vertical skip. The height options denotes the skip dimension.")
 
-  self:registerCommand("discretionary", function (options, _)
-    local discretionary = SILE.types.node.discretionary({})
-    if options.prebreak then
-      local hbox = SILE.typesetter:makeHbox({ options.prebreak })
-      discretionary.prebreak = { hbox }
-    end
-    if options.postbreak then
-      local hbox = SILE.typesetter:makeHbox({ options.postbreak })
-      discretionary.postbreak = { hbox }
-    end
-    if options.replacement then
-      local hbox = SILE.typesetter:makeHbox({ options.replacement })
-      discretionary.replacement = { hbox }
-    end
-    table.insert(SILE.typesetter.state.nodes, discretionary)
-  end, "Inserts a discretionary node.")
-
-  self:registerCommand("glue", function (options, _)
-    local width = SU.cast("length", options.width):absolute()
-    SILE.typesetter:pushGlue(width)
-  end, "Inserts a glue node. The width option denotes the glue dimension.")
-
-  self:registerCommand("kern", function (options, _)
-    local width = SU.cast("length", options.width):absolute()
-    SILE.typesetter:pushHorizontal(SILE.types.node.kern(width))
-  end, "Inserts a glue node. The width option denotes the glue dimension.")
-
-  self:registerCommand("skip", function (options, _)
-    options.discardable = SU.boolean(options.discardable, false)
-    options.height = SILE.types.length(options.height):absolute()
-    SILE.typesetter:leaveHmode()
-    if options.discardable then
-      SILE.typesetter:pushVglue(options)
-    else
-      SILE.typesetter:pushExplicitVglue(options)
-    end
-  end, "Inserts vertical skip. The height options denotes the skip dimension.")
-
-  self:registerCommand("par", function (_, _)
-    SILE.typesetter:endline()
-  end, "Ends the current paragraph.")
-
+   self:registerCommand("par", function (_, _)
+      SILE.typesetter:endline()
+   end, "Ends the current paragraph.")
 end
 
 function class:initialFrame ()
-  SILE.documentState.thisPageTemplate = pl.tablex.deepcopy(self.pageTemplate)
-  SILE.frames = { page = SILE.frames.page }
-  for k, v in pairs(SILE.documentState.thisPageTemplate.frames) do
-    SILE.frames[k] = v
-  end
-  if not SILE.documentState.thisPageTemplate.firstContentFrame then
-    SILE.documentState.thisPageTemplate.firstContentFrame = SILE.frames[self.firstContentFrame]
-  end
-  SILE.documentState.thisPageTemplate.firstContentFrame:invalidate()
-  return SILE.documentState.thisPageTemplate.firstContentFrame
+   SILE.documentState.thisPageTemplate = pl.tablex.deepcopy(self.pageTemplate)
+   SILE.frames = { page = SILE.frames.page }
+   for k, v in pairs(SILE.documentState.thisPageTemplate.frames) do
+      SILE.frames[k] = v
+   end
+   if not SILE.documentState.thisPageTemplate.firstContentFrame then
+      SILE.documentState.thisPageTemplate.firstContentFrame = SILE.frames[self.firstContentFrame]
+   end
+   SILE.documentState.thisPageTemplate.firstContentFrame:invalidate()
+   return SILE.documentState.thisPageTemplate.firstContentFrame
 end
 
 function class:declareFrame (id, spec)
-  spec.id = id
-  if spec.solve then
-    self.pageTemplate.frames[id] = spec
-  else
-    self.pageTemplate.frames[id] = SILE.newFrame(spec)
-  end
-  --   next = spec.next,
-  --   left = spec.left and fW(spec.left),
-  --   right = spec.right and fW(spec.right),
-  --   top = spec.top and fH(spec.top),
-  --   bottom = spec.bottom and fH(spec.bottom),
-  --   height = spec.height and fH(spec.height),
-  --   width = spec.width and fH(spec.width),
-  --   id = id
-  -- })
+   spec.id = id
+   if spec.solve then
+      self.pageTemplate.frames[id] = spec
+   else
+      self.pageTemplate.frames[id] = SILE.newFrame(spec)
+   end
+   --   next = spec.next,
+   --   left = spec.left and fW(spec.left),
+   --   right = spec.right and fW(spec.right),
+   --   top = spec.top and fH(spec.top),
+   --   bottom = spec.bottom and fH(spec.bottom),
+   --   height = spec.height and fH(spec.height),
+   --   width = spec.width and fH(spec.width),
+   --   id = id
+   -- })
 end
 
 function class:declareFrames (specs)
-  if specs then
-    for k, v in pairs(specs) do self:declareFrame(k, v) end
-  end
+   if specs then
+      for k, v in pairs(specs) do
+         self:declareFrame(k, v)
+      end
+   end
 end
 
 -- WARNING: not called as class method
 function class.newPar (typesetter)
-  local parindent = SILE.settings:get("current.parindent") or SILE.settings:get("document.parindent")
-  -- See https://github.com/sile-typesetter/sile/issues/1361
-  -- The parindent *cannot* be pushed non-absolutized, as it may be evaluated
-  -- outside the (possibly temporary) setting scope where it was used for line
-  -- breaking.
-  -- Early absolutization can be problematic sometimes, but here we do not
-  -- really have the choice.
-  -- As of problematic cases, consider a parindent that would be defined in a
-  -- frame-related unit (%lw, %fw, etc.). If a frame break occurs and the next
-  -- frame has a different width, the parindent won't be re-evaluated in that
-  -- new frame context. However, defining a parindent in such a unit is quite
-  -- unlikely. And anyway pushback() has plenty of other issues.
-  typesetter:pushGlue(parindent:absolute())
-  SILE.settings:set("current.parindent", nil)
-  -- BEGIN SILEX HANGED LINES
-  --   (MOVED TO THE TYPESETTER)
-  -- END SILEX HANGED LINES
+   local parindent = SILE.settings:get("current.parindent") or SILE.settings:get("document.parindent")
+   -- See https://github.com/sile-typesetter/sile/issues/1361
+   -- The parindent *cannot* be pushed non-absolutized, as it may be evaluated
+   -- outside the (possibly temporary) setting scope where it was used for line
+   -- breaking.
+   -- Early absolutization can be problematic sometimes, but here we do not
+   -- really have the choice.
+   -- As of problematic cases, consider a parindent that would be defined in a
+   -- frame-related unit (%lw, %fw, etc.). If a frame break occurs and the next
+   -- frame has a different width, the parindent won't be re-evaluated in that
+   -- new frame context. However, defining a parindent in such a unit is quite
+   -- unlikely. And anyway pushback() has plenty of other issues.
+   typesetter:pushGlue(parindent:absolute())
+   SILE.settings:set("current.parindent", nil)
+   -- BEGIN SILEX HANGED LINES
+   --   (MOVED TO THE TYPESETTER)
+   -- END SILEX HANGED LINES
 end
 
 -- WARNING: not called as class method
 function class.endPar (typesetter)
-  typesetter:pushVglue(SILE.settings:get("document.parskip"))
+   typesetter:pushVglue(SILE.settings:get("document.parskip"))
   -- BEGIN SILEX HANGED LINES
   --   (MOVED TO THE TYPESETTER)
   -- END SILEX HANGED LINES
 end
 
 function class:newPage ()
-  SILE.outputter:newPage()
-  self:runHooks("newpage")
-  -- Any other output-routiney things will be done here by inheritors
-  return self:initialFrame()
+   SILE.outputter:newPage()
+   self:runHooks("newpage")
+   -- Any other output-routiney things will be done here by inheritors
+   return self:initialFrame()
 end
 
 function class:endPage ()
-  SILE.typesetter.frame:leave(SILE.typesetter)
-  self:runHooks("endpage")
-  -- I'm trying to call up a new frame here, don't cause a page break in the current one
-  -- SILE.typesetter:leaveHmode()
-  -- Any other output-routiney things will be done here by inheritors
+   SILE.typesetter.frame:leave(SILE.typesetter)
+   self:runHooks("endpage")
+   -- I'm trying to call up a new frame here, don't cause a page break in the current one
+   -- SILE.typesetter:leaveHmode()
+   -- Any other output-routiney things will be done here by inheritors
 end
 
 function class:finish ()
-  SILE.inputter:postamble()
-  SILE.call("vfill")
-  while not SILE.typesetter:isQueueEmpty() do
-    SILE.call("supereject")
-    SILE.typesetter:leaveHmode(true)
-    SILE.typesetter:buildPage()
-    if not SILE.typesetter:isQueueEmpty() then
-      SILE.typesetter:initNextFrame()
-    end
-  end
-  SILE.typesetter:runHooks("pageend") -- normally run by the typesetter
-  self:endPage()
-    if SILE.typesetter then
-      assert(SILE.typesetter:isQueueEmpty(), "queues not empty")
-    end
-  SILE.outputter:finish()
-  self:runHooks("finish")
+   SILE.inputter:postamble()
+   SILE.call("vfill")
+   while not SILE.typesetter:isQueueEmpty() do
+      SILE.call("supereject")
+      SILE.typesetter:leaveHmode(true)
+      SILE.typesetter:buildPage()
+      if not SILE.typesetter:isQueueEmpty() then
+         SILE.typesetter:initNextFrame()
+      end
+   end
+   SILE.typesetter:runHooks("pageend") -- normally run by the typesetter
+   self:endPage()
+   if SILE.typesetter and not SILE.typesetter:isQueueEmpty() then
+      SU.error("Queues are not empty as expected after ending last page", true)
+   end
+   SILE.outputter:finish()
+   self:runHooks("finish")
 end
 
 return class

--- a/silex/packages/background/init.lua
+++ b/silex/packages/background/init.lua
@@ -6,52 +6,57 @@ package._name = "background"
 local background = {}
 
 local outputBackground = function ()
-  local pagea = SILE.getFrame("page")
-  local offset = SILE.documentState.bleed / 2
-  if type(background.bg) == "string" then
-    SILE.outputter:drawImage(background.bg,
-      pagea:left() - offset, pagea:top() - offset,
-      pagea:width() + 2 * offset, pagea:height() + 2 * offset)
-  elseif background.bg then
-    SILE.outputter:pushColor(background.bg)
-    SILE.outputter:drawRule(
-      pagea:left() - offset, pagea:top() - offset,
-      pagea:width() + 2 * offset, pagea:height() + 2 * offset)
-    SILE.outputter:popColor()
-  end
-  if not background.allpages then
-    background.bg = nil
-  end
+   local pagea = SILE.getFrame("page")
+   local offset = SILE.documentState.bleed / 2
+   if type(background.bg) == "string" then
+      SILE.outputter:drawImage(
+         background.bg,
+         pagea:left() - offset,
+         pagea:top() - offset,
+         pagea:width() + 2 * offset,
+         pagea:height() + 2 * offset
+      )
+   elseif background.bg then
+      SILE.outputter:pushColor(background.bg)
+      SILE.outputter:drawRule(
+         pagea:left() - offset,
+         pagea:top() - offset,
+         pagea:width() + 2 * offset,
+         pagea:height() + 2 * offset
+      )
+      SILE.outputter:popColor()
+   end
+   if not background.allpages then
+      background.bg = nil
+   end
 end
 
 function package:_init ()
-  base._init(self)
-  self.class:registerHook("newpage", outputBackground)
+   base._init(self)
+   self.class:registerHook("newpage", outputBackground)
 end
 
 function package:registerCommands ()
+   self:registerCommand("background", function (options, _)
+      if SU.boolean(options.disable, false) then
+         -- This option is certainly better than enforcing a white color.
+         background.bg = nil
+         return
+      end
 
-  self:registerCommand("background", function (options, _)
-    if SU.boolean(options.disable, false) then
-      -- This option is certainly better than enforcing a white color.
-      background.bg = nil
-      return
-    end
-
-    local allpages = SU.boolean(options.allpages, true)
-    background.allpages = allpages
-    local color = options.color and SILE.types.color(options.color)
-    local src = options.src
-    if src then
-      background.bg = src and SILE.resolveFile(src) or SU.error("Couldn't find file "..src)
-    elseif color then
-      background.bg = color
-    else
-      SU.error("background requires a color or an image src parameter")
-    end
-    outputBackground(SILE.scratch.background)
-  end, "Output a solid background color <color> or an image <src> on pages after initialization.")
-
+      local allpages = SU.boolean(options.allpages, true)
+      background.allpages = allpages
+      local color = options.color and SILE.types.color(options.color)
+      local src = options.src
+      if src then
+         background.bg = src and SILE.resolveFile(src) or SU.error("Couldn't find file " .. src)
+      elseif color then
+         background.bg = color
+      else
+         SU.error("background requires a color or an image src parameter")
+      end
+      outputBackground()
+   end, "Output a solid background color <color> or an image <src> on pages after initialization.")
 end
 
 package.documentation = [[
@@ -62,7 +67,7 @@ As its name implies, the \autodoc:package{background} package allows you to set 
 The package provides a \autodoc:command{\background} command which requires one of the following parameters:
 \begin{itemize}
 \item{\autodoc:parameter{color=<color specification>} sets the background of the current and all following pages to that color. The color specification has the same syntax as specified in the \autodoc:package{color} package.}
-\item{\autodoc:parameter{src=<file>} sets the backgound of the current and all following pages to the specified image. The latter will be scaled to the target dimension.}
+\item{\autodoc:parameter{src=<file>} sets the background of the current and all following pages to the specified image. The latter will be scaled to the target dimension.}
 \end{itemize}
 
 The background extends to the page trim area (“page bleed”) if the latter is defined.

--- a/silex/packages/color/init.lua
+++ b/silex/packages/color/init.lua
@@ -4,21 +4,19 @@ local package = pl.class(base)
 package._name = "color"
 
 function package:registerCommands ()
-
-  self:registerCommand("color", function (options, content)
-    local color = SILE.types.color(options.color or "black")
-    -- This is a bit of a hack to use a liner.
-    -- (Due to how the color stack is currently handled)
-    -- If the content spans multiple lines, and a page break occurs in between,
-    -- this avoids the color being propagated to other page content.
-    -- (folio, footnotes, etc.)
-    SILE.typesetter:liner("color", content, function (box, typesetter, line)
-      SILE.outputter:pushColor(color)
-      box:outputContent(typesetter, line)
-      SILE.outputter:popColor()
-    end)
-  end, "Changes the active ink color to the color <color>.")
-
+   self:registerCommand("color", function (options, content)
+      local color = SILE.types.color(options.color or "black")
+      -- This is a bit of a hack to use a liner.
+      -- (Due to how the color stack is currently handled)
+      -- If the content spans multiple lines, and a page break occurs in between,
+      -- this avoids the color being propagated to other page content.
+      -- (folio, footnotes, etc.)
+      SILE.typesetter:liner("color", content, function (box, typesetter, line)
+         SILE.outputter:pushColor(color)
+         box:outputContent(typesetter, line)
+         SILE.outputter:popColor()
+      end)
+   end, "Changes the active ink color to the color <color>.")
 end
 
 package.documentation = [[

--- a/silex/packages/cropmarks/init.lua
+++ b/silex/packages/cropmarks/init.lua
@@ -6,73 +6,73 @@ package._name = "cropmarks"
 local outcounter = 1
 
 local function outputMarks ()
-  local page = SILE.getFrame("page")
-  -- Length of crop mark bars
-  local cropsz = 20
-  -- Ensure the crop marks stay outside the bleed area
-  local offset = math.max(10, SILE.documentState.bleed / 2)
+   local page = SILE.getFrame("page")
+   -- Length of crop mark bars
+   local cropsz = 20
+   -- Ensure the crop marks stay outside the bleed area
+   local offset = math.max(10, SILE.documentState.bleed / 2)
 
-  SILE.outputter:drawRule(page:left() - offset, page:top(), -cropsz, 0.5)
-  SILE.outputter:drawRule(page:left(), page:top() - offset, 0.5, -cropsz)
-  SILE.outputter:drawRule(page:right() + offset, page:top(), cropsz, 0.5)
-  SILE.outputter:drawRule(page:right(), page:top() - offset, 0.5, -cropsz)
-  SILE.outputter:drawRule(page:left() - offset, page:bottom(), -cropsz, 0.5)
-  SILE.outputter:drawRule(page:left() , page:bottom() + offset, 0.5, cropsz)
-  SILE.outputter:drawRule(page:right() + offset, page:bottom(), cropsz, 0.5)
-  SILE.outputter:drawRule(page:right(), page:bottom() + offset, 0.5, cropsz)
+   SILE.outputter:drawRule(page:left() - offset, page:top(), -cropsz, 0.5)
+   SILE.outputter:drawRule(page:left(), page:top() - offset, 0.5, -cropsz)
+   SILE.outputter:drawRule(page:right() + offset, page:top(), cropsz, 0.5)
+   SILE.outputter:drawRule(page:right(), page:top() - offset, 0.5, -cropsz)
+   SILE.outputter:drawRule(page:left() - offset, page:bottom(), -cropsz, 0.5)
+   SILE.outputter:drawRule(page:left(), page:bottom() + offset, 0.5, cropsz)
+   SILE.outputter:drawRule(page:right() + offset, page:bottom(), cropsz, 0.5)
+   SILE.outputter:drawRule(page:right(), page:bottom() + offset, 0.5, cropsz)
 
-  local hbox, hlist = SILE.typesetter:makeHbox(function ()
-    SILE.settings:temporarily(function ()
-      SILE.call("noindent")
-      SILE.call("font", { size="6pt" })
-      if SILE.Commands["crop:header"] then
-        -- Deprecation shim:
-        -- If user redefined this command, still use it with a warning...
-        SU.deprecated("crop:header", "cropmarks:header", "0.15.0", "0.16.0")
-        SILE.call("crop:header")
-      else
-        SILE.call("cropmarks:header")
+   local hbox, hlist = SILE.typesetter:makeHbox(function ()
+      SILE.settings:temporarily(function ()
+         SILE.call("noindent")
+         SILE.call("font", { size = "6pt" })
+         if SILE.Commands["crop:header"] then
+         -- Deprecation shim:
+         -- If user redefined this command, still use it with a warning...
+         SU.deprecated("crop:header", "cropmarks:header", "0.15.0", "0.16.0")
+         SILE.call("crop:header")
+         else
+            SILE.call("cropmarks:header")
+         end
+      end)
+   end)
+   if #hlist > 0 then
+      SU.error("Migrating content is forbidden in crop header")
+   end
+
+   SILE.typesetter.frame.state.cursorX = page:left() + offset
+   SILE.typesetter.frame.state.cursorY = page:top() - offset - 4
+   outcounter = outcounter + 1
+
+   if hbox then
+      for i = 1, #hbox.value do
+         hbox.value[i]:outputYourself(SILE.typesetter, { ratio = 1 })
       end
-    end)
-  end)
-  if #hlist > 0 then
-    SU.error("Migrating content is forbidden in crop header")
-  end
-
-  SILE.typesetter.frame.state.cursorX = page:left() + offset
-  SILE.typesetter.frame.state.cursorY = page:top() - offset - 4
-  outcounter = outcounter + 1
-
-  if hbox then
-    for i = 1, #(hbox.value) do
-      hbox.value[i]:outputYourself(SILE.typesetter, { ratio = 1 })
-    end
-  end
+   end
 end
 
 function package:_init ()
-  base._init(self)
-  self:loadPackage("date")
+   base._init(self)
+   self:loadPackage("date")
 end
 
 function package:registerCommands ()
+   self:registerCommand("cropmarks:header", function (_, _)
+      local info = SILE.input.filenames[1]
+         .. " - "
+         .. self.class.packages.date:date({ format = "%x %X" })
+         .. " - "
+         .. outcounter
+      SILE.typesetter:typeset(info)
+   end)
 
-  self:registerCommand("cropmarks:header", function (_, _)
-    local info = SILE.input.filenames[1]
-       .. " - "
-       .. self.class.packages.date:date({ format = "%x %X" })
-       .. " - " .. outcounter
-    SILE.typesetter:typeset(info)
-  end)
+   self:registerCommand("cropmarks:setup", function (_, _)
+      self.class:registerHook("endpage", outputMarks)
+   end)
 
-  self:registerCommand("cropmarks:setup", function (_, _)
-    self.class:registerHook("endpage", outputMarks)
-  end)
-
-  self:registerCommand("crop:setup", function (_, _)
-    SU.deprecated("crop:setup", "cropmarks:setup", "0.15.10", "0.17.0")
-    SILE.call("cropmarks:setup")
-  end)
+   self:registerCommand("crop:setup", function (_, _)
+      SU.deprecated("crop:setup", "cropmarks:setup", "0.15.10", "0.17.0")
+      SILE.call("cropmarks:setup")
+   end)
 end
 
 package.documentation = [[

--- a/silex/packages/pdf/init.lua
+++ b/silex/packages/pdf/init.lua
@@ -1,4 +1,6 @@
---
+--- pdf package
+--- @use packages.pdf
+
 -- This package and its commands are perhaps ill-named:
 -- Exception made of the pdf:literal command below, the concepts of links
 -- (anchor, target), bookmarks, and metadata are not specific to PDF.
@@ -9,80 +11,75 @@ local package = pl.class(base)
 package._name = "pdf"
 
 function package:registerCommands ()
+   self:registerCommand("pdf:destination", function (options, _)
+      local name = SU.required(options, "name", "pdf:destination")
+      SILE.typesetter:pushHbox({
+         outputYourself = function (_, typesetter, line)
+            local state = typesetter.frame.state
+            typesetter.frame:advancePageDirection(-line.height)
+            local x, y = state.cursorX, state.cursorY
+            typesetter.frame:advancePageDirection(line.height)
+            local _y = SILE.documentState.paperSize[2] - y
+            SILE.outputter:setLinkAnchor(name, x, _y)
+         end,
+      })
+   end)
 
-  self:registerCommand("pdf:destination", function (options, _)
-    local name = SU.required(options, "name", "pdf:destination")
-    SILE.typesetter:pushHbox({
-      outputYourself = function (_, typesetter, line)
-        local state = typesetter.frame.state
-        typesetter.frame:advancePageDirection(-line.height)
-        local x, y = state.cursorX, state.cursorY
-        typesetter.frame:advancePageDirection(line.height)
-        local _y = SILE.documentState.paperSize[2] - y
-        SILE.outputter:setLinkAnchor(name, x, _y)
+   self:registerCommand("pdf:bookmark", function (options, _)
+      local dest = SU.required(options, "dest", "pdf:bookmark")
+      local title = SU.required(options, "title", "pdf:bookmark")
+      local level = SU.cast("integer", options.level or 1)
+      SILE.typesetter:pushHbox({
+         value = nil,
+         height = SILE.types.measurement(0),
+         width = SILE.types.measurement(0),
+         depth = SILE.types.measurement(0),
+         outputYourself = function ()
+            SILE.outputter:setBookmark(dest, title, level)
+         end,
+      })
+   end)
+
+   -- TODO: Shim to pdfannotations package
+   -- self:registerCommand("pdf:literal", function (_, content)
+   self:registerCommand("pdf:link", function (options, content)
+      local dest = SU.required(options, "dest", "pdf:link")
+      local external = SU.boolean(options.external, false)
+      local borderwidth = options.borderwidth and SU.cast("measurement", options.borderwidth):tonumber() or 0
+      local bordercolor = SILE.types.color(options.bordercolor or "blue")
+      local borderoffset = SU.cast("measurement", options.borderoffset or "1pt"):tonumber()
+      local opts = {
+         external = external,
+         borderstyle = options.borderstyle,
+         bordercolor = bordercolor,
+         borderwidth = borderwidth,
+         borderoffset = borderoffset,
+      }
+
+      SILE.typesetter:liner("pdf:link", content, function (box, typesetter, line)
+         local x0 = typesetter.frame.state.cursorX:tonumber()
+         local y0 = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY):tonumber()
+         SILE.outputter:beginLink(dest, opts)
+
+         -- Build the content.
+         -- Cursor will be moved by the actual definitive size.
+         box:outputContent(typesetter, line)
+         local x1 = typesetter.frame.state.cursorX:tonumber()
+         local y1 = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY + box.height):tonumber()
+
+         SILE.outputter:endLink(dest, opts, x0, y0, x1, y1) -- Unstable API
+      end)
+   end)
+
+   self:registerCommand("pdf:metadata", function (options, _)
+      local key = SU.required(options, "key", "pdf:metadata")
+      if options.val ~= nil then
+         SU.deprecated("\\pdf:metadata[…, val=…]", "\\pdf:metadata[…, value=…]", "0.12.0", "0.13.0")
       end
-    })
-  end)
+      local value = SU.required(options, "value", "pdf:metadata")
 
-  self:registerCommand("pdf:bookmark", function (options, _)
-    local dest = SU.required(options, "dest", "pdf:bookmark")
-    local title = SU.required(options, "title", "pdf:bookmark")
-    local level = SU.cast("integer", options.level or 1)
-    SILE.typesetter:pushHbox({
-      value = nil,
-      height = SILE.types.measurement(0),
-      width = SILE.types.measurement(0),
-      depth = SILE.types.measurement(0),
-      outputYourself = function ()
-        SILE.outputter:setBookmark(dest, title, level)
-      end
-    })
-  end)
-
-  -- TODO: Shim to pdfannotations package
-  -- self:registerCommand("pdf:literal", function (_, content)
-  self:registerCommand("pdf:link", function (options, content)
-    local dest = SU.required(options, "dest", "pdf:link")
-    local external = SU.boolean(options.external, false)
-    local borderwidth = options.borderwidth and SU.cast("measurement", options.borderwidth):tonumber() or 0
-    local bordercolor = SILE.types.color(options.bordercolor or "blue")
-    local borderoffset = SU.cast("measurement", options.borderoffset or "1pt"):tonumber()
-    local opts = {
-      external = external,
-      borderstyle = options.borderstyle,
-      bordercolor = bordercolor,
-      borderwidth = borderwidth,
-      borderoffset = borderoffset
-    }
-
-    SILE.typesetter:liner("pdf:link", content,
-      function (box, typesetter, line)
-        local x0 = typesetter.frame.state.cursorX:tonumber()
-        local y0 = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY):tonumber()
-        SILE.outputter:beginLink(dest, opts)
-
-        -- Build the content.
-        -- Cursor will be moved by the actual definitive size.
-        box:outputContent(typesetter, line)
-        local x1 = typesetter.frame.state.cursorX:tonumber()
-        local y1 = (SILE.documentState.paperSize[2] - typesetter.frame.state.cursorY + box.height):tonumber()
-
-        SILE.outputter:endLink(dest, opts, x0, y0, x1, y1) -- Unstable API
-      end
-    )
-
-  end)
-
-  self:registerCommand("pdf:metadata", function (options, _)
-    local key = SU.required(options, "key", "pdf:metadata")
-    if options.val ~= nil then
-      SU.deprecated("\\pdf:metadata[…, val=…]", "\\pdf:metadata[…, value=…]", "0.12.0", "0.13.0")
-    end
-    local value = SU.required(options, "value", "pdf:metadata")
-
-    SILE.outputter:setMetadata(key, value)
-  end)
-
+      SILE.outputter:setMetadata(key, value)
+   end)
 end
 
 package.documentation = [[

--- a/silex/packages/rotate/init.lua
+++ b/silex/packages/rotate/init.lua
@@ -4,24 +4,35 @@ local package = pl.class(base)
 package._name = "rotate"
 
 local enter = function (self, _)
-  -- Probably broken, see:
-  -- https://github.com/sile-typesetter/sile/issues/427
-  if not self.rotate then return end
-  if not SILE.outputter.enterFrameRotate then
-    return SU.warn("Frame '".. self.id "' will not be rotated: backend '" .. SILE.outputter._name .. "' does not support rotation")
-  end
-  local theta = -math.rad(self.rotate)
-  -- Keep center point the same
-  local x0 = self:left():tonumber()
-  local x1 = x0 + math.sin(theta) * self:height():tonumber()
-  local y0 = self:bottom():tonumber()
-  SILE.outputter:enterFrameRotate(x0, x1, y0, theta) -- Unstable API
+   -- Probably broken, see:
+   -- https://github.com/sile-typesetter/sile/issues/427
+   if not self.rotate then
+      return
+   end
+   if not SILE.outputter.enterFrameRotate then
+      return SU.warn(
+         "Frame '"
+            .. self.id("' will not be rotated: backend '")
+            .. SILE.outputter._name
+            .. "' does not support rotation"
+      )
+   end
+   local theta = -math.rad(self.rotate)
+   -- Keep center point the same
+   local x0 = self:left():tonumber()
+   local x1 = x0 + math.sin(theta) * self:height():tonumber()
+   local y0 = self:bottom():tonumber()
+   SILE.outputter:enterFrameRotate(x0, x1, y0, theta) -- Unstable API
 end
 
-local leave = function(self, _)
-  if not self.rotate then return end
-  if not SILE.outputter.enterFrameRotate then return end -- no enter no leave.
-  SILE.outputter:leaveFrameRotate()
+local leave = function (self, _)
+   if not self.rotate then
+      return
+   end
+   if not SILE.outputter.enterFrameRotate then
+      return
+   end -- no enter no leave.
+   SILE.outputter:leaveFrameRotate()
 end
 
 -- What is the width, depth and height of a rectangle width w and height h rotated by angle theta?
@@ -30,84 +41,84 @@ end
 --                                                     RotationTransform[theta, {w/2,h/2}]]],
 --                                      w > 0 && h > 0 && theta > 0 && theta < 2 Pi ]
 -- PiecewiseExpand[xmax - xmin]
-    -- \[Piecewise]  -w Cos[theta]-h Sin[theta]  Sin[theta]<=0&&Cos[theta]<=0
-    --                w Cos[theta]-h Sin[theta]  Sin[theta]<=0&&Cos[theta]>0
-    --               -w Cos[theta]+h Sin[theta]  Sin[theta]>0&&Cos[theta]<=0
-    --                w Cos[theta]+h Sin[theta]  True
+-- \[Piecewise]  -w Cos[theta]-h Sin[theta]  Sin[theta]<=0&&Cos[theta]<=0
+--                w Cos[theta]-h Sin[theta]  Sin[theta]<=0&&Cos[theta]>0
+--               -w Cos[theta]+h Sin[theta]  Sin[theta]>0&&Cos[theta]<=0
+--                w Cos[theta]+h Sin[theta]  True
 
 local outputRotatedHbox = function (self, typesetter, line)
-  local origbox = self.value.orig
-  local theta = self.value.theta
+   local origbox = self.value.orig
+   local theta = self.value.theta
 
-  -- Find origin of untransformed hbox
-  local X = typesetter.frame.state.cursorX
-  local Y = typesetter.frame.state.cursorY
-  typesetter.frame.state.cursorX = X - (origbox.width.length-self.width)/2
-  local horigin = X + origbox.width.length / 2
-  local vorigin = Y - (origbox.height - origbox.depth) / 2
+   -- Find origin of untransformed hbox
+   local X = typesetter.frame.state.cursorX
+   local Y = typesetter.frame.state.cursorY
+   typesetter.frame.state.cursorX = X - (origbox.width.length - self.width) / 2
+   local horigin = X + origbox.width.length / 2
+   local vorigin = Y - (origbox.height - origbox.depth) / 2
 
-  SILE.outputter:rotateFn(horigin, vorigin, theta, function ()
-    origbox:outputYourself(typesetter, line)
-  end)
-  typesetter.frame.state.cursorX = X
-  typesetter.frame.state.cursorY = Y
-  typesetter.frame:advanceWritingDirection(self.width)
+   SILE.outputter:rotateFn(horigin, vorigin, theta, function ()
+      origbox:outputYourself(typesetter, line)
+   end)
+   typesetter.frame.state.cursorX = X
+   typesetter.frame.state.cursorY = Y
+   typesetter.frame:advanceWritingDirection(self.width)
 end
 
 function package:_init ()
-  base._init(self)
-  if SILE.typesetter and SILE.typesetter.frame then
-    enter(SILE.typesetter.frame, SILE.typesetter)
-    table.insert(SILE.typesetter.frame.leaveHooks, leave)
-  end
-  table.insert(SILE.framePrototype.enterHooks, enter)
-  table.insert(SILE.framePrototype.leaveHooks, leave)
+   base._init(self)
+   if SILE.typesetter and SILE.typesetter.frame then
+      enter(SILE.typesetter.frame, SILE.typesetter)
+      table.insert(SILE.typesetter.frame.leaveHooks, leave)
+   end
+   table.insert(SILE.framePrototype.enterHooks, enter)
+   table.insert(SILE.framePrototype.leaveHooks, leave)
 end
 
 function package:registerCommands ()
-
-  self:registerCommand("rotate", function(options, content)
-    if not SILE.outputter.rotateFn then
-      SU.warn("Output will not be rotated: backend '" .. SILE.outputter._name .. "' does not support rotation")
-      return SILE.process(content)
-    end
-    local angle = SU.required(options, "angle", "rotate command")
-    local theta = -math.rad(angle)
-    local origbox, hlist = SILE.typesetter:makeHbox(content)
-    local h = origbox.height + origbox.depth
-    local w = origbox.width.length
-    local st = math.sin(theta)
-    local ct = math.cos(theta)
-    local height, width, depth
-    if st <= 0 and ct <= 0    then
-      width  = -w * ct - h * st
-      height = 0.5*(h-h*ct-w*st)
-      depth  = 0.5*(h+h*ct+w*st)
-    elseif st <=0 and ct > 0  then
-      width  =  w * ct - h * st
-      height = 0.5*(h+h*ct-w*st)
-      depth  = 0.5*(h-h*ct+w*st)
-    elseif st > 0 and ct <= 0 then
-      width  = -w * ct + h * st
-      height = 0.5*(h-h*ct+w*st)
-      depth  = 0.5*(h+h*ct-w*st)
-    else
-      width  =  w * ct + h * st
-      height = 0.5*(h+h*ct+w*st)
-      depth  = 0.5*(h-h*ct-w*st)
-    end
-    depth = -depth
-    if depth < SILE.types.length(0) then depth = SILE.types.length(0) end
-    SILE.typesetter:pushHbox({
-      value = { orig = origbox, theta = theta},
-      height = height,
-      width = width,
-      depth = depth,
-      outputYourself = outputRotatedHbox
-    })
-    SILE.typesetter:pushHlist(hlist)
-  end)
-
+   self:registerCommand("rotate", function (options, content)
+      if not SILE.outputter.rotateFn then
+         SU.warn("Output will not be rotated: backend '" .. SILE.outputter._name .. "' does not support rotation")
+         return SILE.process(content)
+      end
+      local angle = SU.required(options, "angle", "rotate command")
+      local theta = -math.rad(angle)
+      local origbox, hlist = SILE.typesetter:makeHbox(content)
+      local h = origbox.height + origbox.depth
+      local w = origbox.width.length
+      local st = math.sin(theta)
+      local ct = math.cos(theta)
+      local height, width, depth
+      if st <= 0 and ct <= 0 then
+         width = -w * ct - h * st
+         height = 0.5 * (h - h * ct - w * st)
+         depth = 0.5 * (h + h * ct + w * st)
+      elseif st <= 0 and ct > 0 then
+         width = w * ct - h * st
+         height = 0.5 * (h + h * ct - w * st)
+         depth = 0.5 * (h - h * ct + w * st)
+      elseif st > 0 and ct <= 0 then
+         width = -w * ct + h * st
+         height = 0.5 * (h - h * ct + w * st)
+         depth = 0.5 * (h + h * ct - w * st)
+      else
+         width = w * ct + h * st
+         height = 0.5 * (h + h * ct + w * st)
+         depth = 0.5 * (h - h * ct - w * st)
+      end
+      depth = -depth
+      if depth < SILE.types.length(0) then
+         depth = SILE.types.length(0)
+      end
+      SILE.typesetter:pushHbox({
+         value = { orig = origbox, theta = theta },
+         height = height,
+         width = width,
+         depth = depth,
+         outputYourself = outputRotatedHbox,
+      })
+      SILE.typesetter:pushHlist(hlist)
+   end)
 end
 
 package.documentation = [[

--- a/silex/packages/rules/init.lua
+++ b/silex/packages/rules/init.lua
@@ -4,25 +4,25 @@ local package = pl.class(base)
 package._name = "rules"
 
 local function getUnderlineParameters ()
-  local ot = require("core.opentype-parser")
-  local fontoptions = SILE.font.loadDefaults({})
-  local face = SILE.font.cache(fontoptions, SILE.shaper.getFace)
-  local font = ot.parseFont(face)
-  local upem = font.head.unitsPerEm
-  local underlinePosition = font.post.underlinePosition / upem * fontoptions.size
-  local underlineThickness = font.post.underlineThickness / upem * fontoptions.size
-  return underlinePosition, underlineThickness
+   local ot = require("core.opentype-parser")
+   local fontoptions = SILE.font.loadDefaults({})
+   local face = SILE.font.cache(fontoptions, SILE.shaper.getFace)
+   local font = ot.parseFont(face)
+   local upem = font.head.unitsPerEm
+   local underlinePosition = font.post.underlinePosition / upem * fontoptions.size
+   local underlineThickness = font.post.underlineThickness / upem * fontoptions.size
+   return underlinePosition, underlineThickness
 end
 
 local function getStrikethroughParameters ()
-  local ot = require("core.opentype-parser")
-  local fontoptions = SILE.font.loadDefaults({})
-  local face = SILE.font.cache(fontoptions, SILE.shaper.getFace)
-  local font = ot.parseFont(face)
-  local upem = font.head.unitsPerEm
-  local yStrikeoutPosition = font.os2.yStrikeoutPosition / upem * fontoptions.size
-  local yStrikeoutSize = font.os2.yStrikeoutSize / upem * fontoptions.size
-  return yStrikeoutPosition, yStrikeoutSize
+   local ot = require("core.opentype-parser")
+   local fontoptions = SILE.font.loadDefaults({})
+   local face = SILE.font.cache(fontoptions, SILE.shaper.getFace)
+   local font = ot.parseFont(face)
+   local upem = font.head.unitsPerEm
+   local yStrikeoutPosition = font.os2.yStrikeoutPosition / upem * fontoptions.size
+   local yStrikeoutSize = font.os2.yStrikeoutSize / upem * fontoptions.size
+   return yStrikeoutPosition, yStrikeoutSize
 end
 
 -- \hfill (from the "plain" class) and \leaders (from the "leaders" package) use glues,
@@ -32,202 +32,196 @@ hrulefillglue.raise = SILE.types.measurement()
 hrulefillglue.thickness = SILE.types.measurement("0.2pt")
 
 function hrulefillglue:outputYourself (typesetter, line)
-  local outputWidth = SU.rationWidth(self.width, self.width, line.ratio):tonumber()
-  local oldx = typesetter.frame.state.cursorX
-  typesetter.frame:advancePageDirection(-self.raise)
-  typesetter.frame:advanceWritingDirection(outputWidth)
-  local newx = typesetter.frame.state.cursorX
-  local newy = typesetter.frame.state.cursorY
-  SILE.outputter:drawRule(oldx, newy, newx - oldx, self.thickness)
-  typesetter.frame:advancePageDirection(self.raise)
+   local outputWidth = SU.rationWidth(self.width, self.width, line.ratio):tonumber()
+   local oldx = typesetter.frame.state.cursorX
+   typesetter.frame:advancePageDirection(-self.raise)
+   typesetter.frame:advanceWritingDirection(outputWidth)
+   local newx = typesetter.frame.state.cursorX
+   local newy = typesetter.frame.state.cursorY
+   SILE.outputter:drawRule(oldx, newy, newx - oldx, self.thickness)
+   typesetter.frame:advancePageDirection(self.raise)
 end
 
 function package:_init ()
-  base._init(self)
-  self:loadPackage("raiselower")
-  self:loadPackage("rebox")
+   base._init(self)
+   self:loadPackage("raiselower")
+   self:loadPackage("rebox")
 end
 
 function package:registerCommands ()
+   self:registerCommand("hrule", function (options, _)
+      local width = SU.cast("length", options.width)
+      local height = SU.cast("length", options.height)
+      local depth = SU.cast("length", options.depth)
+      SILE.typesetter:pushHbox({
+         width = width:absolute(),
+         height = height:absolute(),
+         depth = depth:absolute(),
+         value = options.src,
+         outputYourself = function (node, typesetter, line)
+            local outputWidth = SU.rationWidth(node.width, node.width, line.ratio)
+            typesetter.frame:advancePageDirection(-node.height)
+            local oldx = typesetter.frame.state.cursorX
+            local oldy = typesetter.frame.state.cursorY
+            typesetter.frame:advanceWritingDirection(outputWidth)
+            typesetter.frame:advancePageDirection(node.height + node.depth)
+            local newx = typesetter.frame.state.cursorX
+            local newy = typesetter.frame.state.cursorY
+            SILE.outputter:drawRule(oldx, oldy, newx - oldx, newy - oldy)
+            typesetter.frame:advancePageDirection(-node.depth)
+         end,
+      })
+   end, "Draws a blob of ink of width <width>, height <height> and depth <depth>")
 
-  self:registerCommand("hrule", function (options, _)
-    local width = SU.cast("length", options.width)
-    local height = SU.cast("length", options.height)
-    local depth = SU.cast("length", options.depth)
-    SILE.typesetter:pushHbox({
-      width = width:absolute(),
-      height = height:absolute(),
-      depth = depth:absolute(),
-      value = options.src,
-      outputYourself = function (node, typesetter, line)
-        local outputWidth = SU.rationWidth(node.width, node.width, line.ratio)
-        typesetter.frame:advancePageDirection(-node.height)
-        local oldx = typesetter.frame.state.cursorX
-        local oldy = typesetter.frame.state.cursorY
-        typesetter.frame:advanceWritingDirection(outputWidth)
-        typesetter.frame:advancePageDirection(node.height + node.depth)
-        local newx = typesetter.frame.state.cursorX
-        local newy = typesetter.frame.state.cursorY
-        SILE.outputter:drawRule(oldx, oldy, newx - oldx, newy - oldy)
-        typesetter.frame:advancePageDirection(-node.depth)
+   self:registerCommand("hrulefill", function (options, _)
+      local raise
+      local thickness
+      if options.position and options.raise then
+         SU.error("hrulefill cannot have both position and raise parameters")
       end
-    })
-  end, "Draws a blob of ink of width <width>, height <height> and depth <depth>")
+      if options.thickness then
+         thickness = SU.cast("measurement", options.thickness)
+      end
+      if options.position == "underline" then
+         local underlinePosition, underlineThickness = getUnderlineParameters()
+         thickness = thickness or underlineThickness
+         raise = underlinePosition
+      elseif options.position == "strikethrough" then
+         local yStrikeoutPosition, yStrikeoutSize = getStrikethroughParameters()
+         thickness = thickness or yStrikeoutSize
+         raise = yStrikeoutPosition + thickness / 2
+      elseif options.position then
+         SU.error("Unknown hrulefill position '" .. options.position .. "'")
+      else
+         raise = SU.cast("measurement", options.raise or "0")
+      end
 
-  self:registerCommand("hrulefill", function (options, _)
-    local raise
-    local thickness
-    if options.position and options.raise then
-      SU.error("hrulefill cannot have both position and raise parameters")
-    end
-    if options.thickness then
-      thickness = SU.cast("measurement", options.thickness)
-    end
-    if options.position == "underline" then
-      local underlinePosition, underlineThickness = getUnderlineParameters()
-      thickness = thickness or underlineThickness
-      raise = underlinePosition
-    elseif options.position == "strikethrough" then
-      local yStrikeoutPosition, yStrikeoutSize = getStrikethroughParameters()
-      thickness = thickness or yStrikeoutSize
-      raise = yStrikeoutPosition + thickness / 2
-    elseif options.position then
-      SU.error("Unknown hrulefill position '"..options.position.."'")
-    else
-      raise = SU.cast("measurement", options.raise or "0")
-    end
+      SILE.typesetter:pushExplicitGlue(hrulefillglue({
+         raise = raise,
+         thickness = thickness or SILE.types.measurement("0.2pt"),
+      }))
+   end, "Add a huge horizontal hrule glue")
 
-    SILE.typesetter:pushExplicitGlue(hrulefillglue({
-      raise = raise,
-      thickness = thickness or SILE.types.measurement("0.2pt"),
-    }))
-  end, "Add a huge horizontal hrule glue")
+   self:registerCommand("fullrule", function (options, _)
+      local thickness = SU.cast("measurement", options.thickness or "0.2pt")
+      local raise = SU.cast("measurement", options.raise or "0.5em")
 
-  self:registerCommand("fullrule", function (options, _)
-    local thickness = SU.cast("measurement", options.thickness or "0.2pt")
-    local raise = SU.cast("measurement", options.raise or "0.5em")
-
-    -- BEGIN DEPRECATION COMPATIBILITY
-    if options.height then
-      SU.deprecated("\\fullrule[…, height=…]", "\\fullrule[…, thickness=…]", "0.13.1", "0.15.0")
-      thickness = SU.cast("measurement", options.height)
-    end
-    if not SILE.typesetter:vmode() then
-      SU.deprecated("\\fullrule in horizontal mode", "\\hrule or \\hrulefill", "0.13.1", "0.15.0")
+      -- BEGIN DEPRECATION COMPATIBILITY
+      if options.height then
+         SU.deprecated("\\fullrule[…, height=…]", "\\fullrule[…, thickness=…]", "0.13.1", "0.15.0")
+         thickness = SU.cast("measurement", options.height)
+      end
+      if not SILE.typesetter:vmode() then
+         SU.deprecated("\\fullrule in horizontal mode", "\\hrule or \\hrulefill", "0.13.1", "0.15.0")
+         if options.width then
+         SU.deprecated("\\fullrule with width", "\\hrule and \\raise", "0.13.1", "0.15.0")
+         SILE.call("raise", { height = raise }, function ()
+            SILE.call("hrule", {
+               height = thickness,
+               width = options.width
+            })
+         end)
+         else
+         -- This was very broken anyway, as it was overflowing the line.
+         -- At least we try better...
+         SILE.call("hrulefill", { raise = raise, thickness = thickness })
+         end
+         return
+      end
       if options.width then
-        SU.deprecated("\\fullrule with width", "\\hrule and \\raise", "0.13.1", "0.15.0")
-        SILE.call("raise", { height = raise }, function ()
-          SILE.call("hrule", {
+         SU.deprecated("\\fullrule with width", "\\hrule and \\raise", "0.13.1 ", "0.15.0")
+         SILE.call("raise", { height = raise }, function ()
+         SILE.call("hrule", {
             height = thickness,
             width = options.width
-          })
-        end)
-      else
-        -- This was very broken anyway, as it was overflowing the line.
-        -- At least we try better...
-        SILE.call("hrulefill", { raise = raise, thickness = thickness })
+         })
+         end)
       end
-     return
-    end
-    if options.width then
-      SU.deprecated("\\fullrule with width", "\\hrule and \\raise", "0.13.1 ", "0.15.0")
-      SILE.call("raise", { height = raise }, function ()
-        SILE.call("hrule", {
-          height = thickness,
-          width = options.width
-        })
+   -- END DEPRECATION COMPATIBILITY
+
+      SILE.typesetter:leaveHmode()
+      SILE.call("noindent")
+      SILE.call("hrulefill", { raise = raise, thickness = thickness })
+      SILE.typesetter:leaveHmode()
+   end, "Draw a full width hrule centered on the current line")
+
+   self:registerCommand("underline", function (_, content)
+      local underlinePosition, underlineThickness = getUnderlineParameters()
+
+      SILE.typesetter:liner("underline", content, function (box, typesetter, line)
+         local oldX = typesetter.frame.state.cursorX
+         local Y = typesetter.frame.state.cursorY
+
+         -- Build the content.
+         -- Cursor will be moved by the actual definitive size.
+         box:outputContent(typesetter, line)
+         local newX = typesetter.frame.state.cursorX
+
+         -- Output a line.
+         -- NOTE: According to the OpenType specs, underlinePosition is "the suggested distance of
+         -- the top of the underline from the baseline" so it seems implied that the thickness
+         -- should expand downwards
+         SILE.outputter:drawRule(oldX, Y - underlinePosition, newX - oldX, underlineThickness)
       end)
-    end
-    -- END DEPRECATION COMPATIBILITY
+   end, "Underlines some content")
 
-    SILE.typesetter:leaveHmode()
-    SILE.call("noindent")
-    SILE.call("hrulefill", { raise = raise, thickness = thickness })
-    SILE.typesetter:leaveHmode()
-  end, "Draw a full width hrule centered on the current line")
+   self:registerCommand("strikethrough", function (_, content)
+      local yStrikeoutPosition, yStrikeoutSize = getStrikethroughParameters()
 
-  self:registerCommand("underline", function (_, content)
-    local underlinePosition, underlineThickness = getUnderlineParameters()
+      SILE.typesetter:liner("strikethrough", content, function (box, typesetter, line)
+         local oldX = typesetter.frame.state.cursorX
+         local Y = typesetter.frame.state.cursorY
 
-    SILE.typesetter:liner("underline", content,
-      function (box, typesetter, line)
-        local oldX = typesetter.frame.state.cursorX
-        local Y = typesetter.frame.state.cursorY
+         -- Build the content.
+         -- Cursor will be moved by the actual definitive size.
+         box:outputContent(typesetter, line)
+         local newX = typesetter.frame.state.cursorX
 
-        -- Build the content.
-        -- Cursor will be moved by the actual definitive size.
-        box:outputContent(typesetter, line)
-        local newX = typesetter.frame.state.cursorX
+         -- Output a line.
+         -- NOTE: The OpenType spec is not explicit regarding how the size
+         -- (thickness) affects the position. We opt to distribute evenly
+         SILE.outputter:drawRule(oldX, Y - yStrikeoutPosition - yStrikeoutSize / 2, newX - oldX, yStrikeoutSize)
+      end)
+   end, "Strikes out some content")
 
-        -- Output a line.
-        -- NOTE: According to the OpenType specs, underlinePosition is "the suggested distance of
-        -- the top of the underline from the baseline" so it seems implied that the thickness
-        -- should expand downwards
-        SILE.outputter:drawRule(oldX, Y - underlinePosition, newX - oldX, underlineThickness)
-      end
-    )
-  end, "Underlines some content")
+   self:registerCommand("boxaround", function (_, content)
+      -- This command was not documented and lacks feature.
+      -- Plan replacement with a better suited package.
+      SU.deprecated("\\boxaround (undocumented)", "\\framebox (package)", "0.12.0")
 
-  self:registerCommand("strikethrough", function (_, content)
-    local yStrikeoutPosition, yStrikeoutSize = getStrikethroughParameters()
+      local hbox, hlist = SILE.typesetter:makeHbox(content)
+      -- Re-wrap the hbox in another hbox responsible for boxing it at output
+      -- time, when we will know the line contribution and can compute the scaled width
+      -- of the box, taking into account possible stretching and shrinking.
+      SILE.typesetter:pushHbox({
+         inner = hbox,
+         width = hbox.width,
+         height = hbox.height,
+         depth = hbox.depth,
+         outputYourself = function (node, typesetter, line)
+            local oldX = typesetter.frame.state.cursorX
+            local Y = typesetter.frame.state.cursorY
 
-    SILE.typesetter:liner("strikethrough", content,
-      function (box, typesetter, line)
-        local oldX = typesetter.frame.state.cursorX
-        local Y = typesetter.frame.state.cursorY
+            -- Build the original hbox.
+            -- Cursor will be moved by the actual definitive size.
+            node.inner:outputYourself(SILE.typesetter, line)
+            local newX = typesetter.frame.state.cursorX
 
-        -- Build the content.
-        -- Cursor will be moved by the actual definitive size.
-        box:outputContent(typesetter, line)
-        local newX = typesetter.frame.state.cursorX
+            -- Output a border
+            -- NOTE: Drawn inside the hbox, so borders overlap with inner content.
+            local w = newX - oldX
+            local h = node.height:tonumber()
+            local d = node.depth:tonumber()
+            local thickness = 0.5
 
-        -- Output a line.
-        -- NOTE: The OpenType spec is not explicit regarding how the size
-        -- (thickness) affects the position. We opt to distribute evenly
-        SILE.outputter:drawRule(oldX, Y - yStrikeoutPosition - yStrikeoutSize / 2, newX - oldX, yStrikeoutSize)
-      end
-    )
-  end, "Strikes out some content")
-
-  self:registerCommand("boxaround", function (_, content)
-    -- This command was not documented and lacks feature.
-    -- Plan replacement with a better suited package.
-    SU.deprecated("\\boxaround (undocumented)", "\\framebox (package)", "0.12.0")
-
-    local hbox, hlist = SILE.typesetter:makeHbox(content)
-    -- Re-wrap the hbox in another hbox responsible for boxing it at output
-    -- time, when we will know the line contribution and can compute the scaled width
-    -- of the box, taking into account possible stretching and shrinking.
-    SILE.typesetter:pushHbox({
-      inner = hbox,
-      width = hbox.width,
-      height = hbox.height,
-      depth = hbox.depth,
-      outputYourself = function (node, typesetter, line)
-        local oldX = typesetter.frame.state.cursorX
-        local Y = typesetter.frame.state.cursorY
-
-        -- Build the original hbox.
-        -- Cursor will be moved by the actual definitive size.
-        node.inner:outputYourself(SILE.typesetter, line)
-        local newX = typesetter.frame.state.cursorX
-
-        -- Output a border
-        -- NOTE: Drawn inside the hbox, so borders overlap with inner content.
-        local w = newX - oldX
-        local h = node.height:tonumber()
-        local d = node.depth:tonumber()
-        local thickness = 0.5
-
-        SILE.outputter:drawRule(oldX, Y + d - thickness, w, thickness)
-        SILE.outputter:drawRule(oldX, Y - h, w, thickness)
-        SILE.outputter:drawRule(oldX, Y - h, thickness, h + d)
-        SILE.outputter:drawRule(oldX + w - thickness, Y - h, thickness, h + d)
-      end
-    })
-    SILE.typesetter:pushHlist(hlist)
-  end, "Draws a box around some content")
-
+            SILE.outputter:drawRule(oldX, Y + d - thickness, w, thickness)
+            SILE.outputter:drawRule(oldX, Y - h, w, thickness)
+            SILE.outputter:drawRule(oldX, Y - h, thickness, h + d)
+            SILE.outputter:drawRule(oldX + w - thickness, Y - h, thickness, h + d)
+         end,
+      })
+      SILE.typesetter:pushHlist(hlist)
+   end, "Draws a box around some content")
 end
 
 package.documentation = [[

--- a/silex/packages/scalebox/init.lua
+++ b/silex/packages/scalebox/init.lua
@@ -4,52 +4,50 @@ local package = pl.class(base)
 package._name = "scalebox"
 
 function package:registerCommands ()
-
-  self:registerCommand("scalebox", function(options, content)
-    if not SILE.outputter.scaleFn then
-      SU.warn("Output will not be scaled: backend '" .. SILE.outputter._name .. "' does not support scaling")
-      return SILE.process(content)
-    end
-
-    local hbox, hlist = SILE.typesetter:makeHbox(content)
-    local xratio, yratio = SU.cast("number", options.xratio or 1), SU.cast("number", options.yratio or 1)
-    if xratio == 0 or yratio == 0 then
-      SU.error("Scaling ratio cannot be null")
-    end
-
-    local W = hbox.width * math.abs(xratio)
-    local H, D
-    if yratio > 0 then
-      H = hbox.height * yratio
-      D = hbox.depth * yratio
-    else
-      H = hbox.depth * -yratio
-      D = hbox.height * -yratio
-    end
-
-    SILE.typesetter:pushHbox({
-      width = W,
-      height = H,
-      depth = D,
-      outputYourself = function(node, typesetter, line)
-        local outputWidth = SU.rationWidth(node.width, node.width, line.ratio)
-        local X = typesetter.frame.state.cursorX
-        local Y = typesetter.frame.state.cursorY
-
-        if xratio < 0 then
-          typesetter.frame:advanceWritingDirection(-outputWidth)
-        end
-        SILE.outputter:scaleFn(X, Y, xratio, yratio, function ()
-          hbox:outputYourself(typesetter, line)
-        end)
-        typesetter.frame.state.cursorX = X
-        typesetter.frame.state.cursorY = Y
-        typesetter.frame:advanceWritingDirection(outputWidth)
+   self:registerCommand("scalebox", function (options, content)
+      if not SILE.outputter.scaleFn then
+         SU.warn("Output will not be scaled: backend '" .. SILE.outputter._name .. "' does not support scaling")
+         return SILE.process(content)
       end
-    })
-    SILE.typesetter:pushHlist(hlist)
-  end, "Scale content by some horizontal and vertical ratios")
 
+      local hbox, hlist = SILE.typesetter:makeHbox(content)
+      local xratio, yratio = SU.cast("number", options.xratio or 1), SU.cast("number", options.yratio or 1)
+      if xratio == 0 or yratio == 0 then
+         SU.error("Scaling ratio cannot be null")
+      end
+
+      local W = hbox.width * math.abs(xratio)
+      local H, D
+      if yratio > 0 then
+         H = hbox.height * yratio
+         D = hbox.depth * yratio
+      else
+         H = hbox.depth * -yratio
+         D = hbox.height * -yratio
+      end
+
+      SILE.typesetter:pushHbox({
+         width = W,
+         height = H,
+         depth = D,
+         outputYourself = function (node, typesetter, line)
+            local outputWidth = SU.rationWidth(node.width, node.width, line.ratio)
+            local X = typesetter.frame.state.cursorX
+            local Y = typesetter.frame.state.cursorY
+
+            if xratio < 0 then
+               typesetter.frame:advanceWritingDirection(-outputWidth)
+            end
+            SILE.outputter:scaleFn(X, Y, xratio, yratio, function ()
+               hbox:outputYourself(typesetter, line)
+            end)
+            typesetter.frame.state.cursorX = X
+            typesetter.frame.state.cursorY = Y
+            typesetter.frame:advanceWritingDirection(outputWidth)
+         end,
+      })
+      SILE.typesetter:pushHlist(hlist)
+   end, "Scale content by some horizontal and vertical ratios")
 end
 
 package.documentation = [[

--- a/silex/packages/url/init.lua
+++ b/silex/packages/url/init.lua
@@ -11,137 +11,154 @@ local preferBreakAfter = ":/.;?&=!_-"
 local alwaysBreakAfter = ":" -- Must have only one character here!
 
 local escapeRegExpMinimal = function (str)
-  -- Minimalist = just what's needed for the above strings
-  return string.gsub(str, '([%.%?%-%%])', '%%%1')
+   -- Minimalist = just what's needed for the above strings
+   return string.gsub(str, "([%.%?%-%%])", "%%%1")
 end
 
-local breakPattern = "["..escapeRegExpMinimal(preferBreakBefore..preferBreakAfter..alwaysBreakAfter).."]"
+local breakPattern = "[" .. escapeRegExpMinimal(preferBreakBefore .. preferBreakAfter .. alwaysBreakAfter) .. "]"
 
 function package:_init ()
-  base._init(self)
-  self:loadPackage("inputfilter")
-  self:loadPackage("pdf")
+   base._init(self)
+   self:loadPackage("inputfilter")
+   self:loadPackage("pdf")
 end
 
 function package.declareSettings (_)
+   SILE.settings:declare({
+      parameter = "url.linebreak.primaryPenalty",
+      type = "integer",
+      default = 100,
+      help = "Penalty for breaking lines in URLs at preferred breakpoints",
+   })
 
-  SILE.settings:declare({
-    parameter = "url.linebreak.primaryPenalty",
-    type = "integer",
-    default = 100,
-    help = "Penalty for breaking lines in URLs at preferred breakpoints"
-  })
-
-  SILE.settings:declare({
-    parameter = "url.linebreak.secondaryPenalty",
-    type = "integer",
-    default = 200,
-    help = "Penalty for breaking lines in URLs at tolerable breakpoints (should be higher than url.linebreak.primaryPenalty)"
-  })
-
+   SILE.settings:declare({
+      parameter = "url.linebreak.secondaryPenalty",
+      type = "integer",
+      default = 200,
+      help = "Penalty for breaking lines in URLs at tolerable breakpoints (should be higher than url.linebreak.primaryPenalty)",
+   })
 end
 
 function package:registerCommands ()
-
-  self:registerCommand("href", function (options, content)
-    if options.src then
-      SILE.call("pdf:link", { dest = options.src, external = true,
-        borderwidth = options.borderwidth,
-        borderstyle = options.borderstyle,
-        bordercolor = options.bordercolor,
-        borderoffset = options.borderoffset },
-        content)
-    else
-      options.src = content[1]
-      SILE.call("pdf:link", { dest = options.src, external = true,
-        borderwidth = options.borderwidth,
-        borderstyle = options.borderstyle,
-        bordercolor = options.bordercolor,
-        borderoffset = options.borderoffset },
-        function (_, _)
-          SILE.call("url", { language = options.language }, content)
-        end)
-    end
-  end, "Inserts a PDF hyperlink.")
-
-  local urlFilter = function (node, content, options)
-    if type(node) == "table" then return node end
-    local result = {}
-    for token in SU.gtoke(node, breakPattern) do
-      if token.string then
-        result[#result+1] = token.string
+   self:registerCommand("href", function (options, content)
+      if options.src then
+         SILE.call("pdf:link", {
+            dest = options.src,
+            external = true,
+            borderwidth = options.borderwidth,
+            borderstyle = options.borderstyle,
+            bordercolor = options.bordercolor,
+            borderoffset = options.borderoffset,
+         }, content)
       else
-        if string.find(preferBreakBefore, escapeRegExpMinimal(token.separator)) then
-          -- Accepts breaking before, and at the extreme worst after.
-          result[#result+1] = self.class.packages.inputfilter:createCommand(
-          content.pos, content.col, content.lno,
-          "penalty", { penalty = options.primaryPenalty }
-          )
-          result[#result+1] = token.separator
-          result[#result+1] = self.class.packages.inputfilter:createCommand(
-          content.pos, content.col, content.lno,
-          "penalty", { penalty = options.worsePenalty }
-          )
-        elseif token.separator == alwaysBreakAfter then
-          -- Accept breaking after (only).
-          result[#result+1] = token.separator
-          result[#result+1] = self.class.packages.inputfilter:createCommand(
-          content.pos, content.col, content.lno,
-          "penalty", { penalty = options.primaryPenalty }
-          )
-        else
-          -- Accept breaking after, but tolerate breaking before.
-          result[#result+1] = self.class.packages.inputfilter:createCommand(
-          content.pos, content.col, content.lno,
-          "penalty", { penalty = options.secondaryPenalty }
-          )
-          result[#result+1] = token.separator
-          result[#result+1] = self.class.packages.inputfilter:createCommand(
-          content.pos, content.col, content.lno,
-          "penalty", { penalty = options.primaryPenalty }
-          )
-        end
+         options.src = content[1]
+         SILE.call("pdf:link", {
+            dest = options.src,
+            external = true,
+            borderwidth = options.borderwidth,
+            borderstyle = options.borderstyle,
+            bordercolor = options.bordercolor,
+            borderoffset = options.borderoffset,
+         }, function (_, _)
+            SILE.call("url", { language = options.language }, content)
+         end)
       end
-    end
-    return result
-  end
+   end, "Inserts a PDF hyperlink.")
 
-  self:registerCommand("url", function (options, content)
-    SILE.settings:temporarily(function ()
-      local primaryPenalty = SILE.settings:get("url.linebreak.primaryPenalty")
-      local secondaryPenalty = SILE.settings:get("url.linebreak.secondaryPenalty")
-      local worsePenalty = primaryPenalty + secondaryPenalty
-
-      if options.language then
-        SILE.languageSupport.loadLanguage(options.language)
-        if options.language == "fr" then
-          -- Trick the engine by declaring a "fake"" language that doesn't apply
-          -- the typographic rules for punctuations
-          SILE.hyphenator.languages["_fr_noSpacingRules"] = SILE.hyphenator.languages.fr
-          -- Not needed (the engine already defaults to SILE.nodeMakers.unicode if
-          -- the language is not found):
-          -- SILE.nodeMakers._fr_noSpacingRules = SILE.nodeMakers.unicode
-          SILE.settings:set("document.language", "_fr_noSpacingRules")
-        else
-          SILE.settings:set("document.language", options.language)
-        end
-      else
-        SILE.settings:set("document.language", 'und')
+   local urlFilter = function (node, content, options)
+      if type(node) == "table" then
+         return node
       end
+      local result = {}
+      for token in SU.gtoke(node, breakPattern) do
+         if token.string then
+            result[#result + 1] = token.string
+         else
+            if string.find(preferBreakBefore, escapeRegExpMinimal(token.separator)) then
+               -- Accepts breaking before, and at the extreme worst after.
+               result[#result + 1] = self.class.packages.inputfilter:createCommand(
+                  content.pos,
+                  content.col,
+                  content.lno,
+                  "penalty",
+                  { penalty = options.primaryPenalty }
+               )
+               result[#result + 1] = token.separator
+               result[#result + 1] = self.class.packages.inputfilter:createCommand(
+                  content.pos,
+                  content.col,
+                  content.lno,
+                  "penalty",
+                  { penalty = options.worsePenalty }
+               )
+            elseif token.separator == alwaysBreakAfter then
+               -- Accept breaking after (only).
+               result[#result + 1] = token.separator
+               result[#result + 1] = self.class.packages.inputfilter:createCommand(
+                  content.pos,
+                  content.col,
+                  content.lno,
+                  "penalty",
+                  { penalty = options.primaryPenalty }
+               )
+            else
+               -- Accept breaking after, but tolerate breaking before.
+               result[#result + 1] = self.class.packages.inputfilter:createCommand(
+                  content.pos,
+                  content.col,
+                  content.lno,
+                  "penalty",
+                  { penalty = options.secondaryPenalty }
+               )
+               result[#result + 1] = token.separator
+               result[#result + 1] = self.class.packages.inputfilter:createCommand(
+                  content.pos,
+                  content.col,
+                  content.lno,
+                  "penalty",
+                  { penalty = options.primaryPenalty }
+               )
+            end
+         end
+      end
+      return result
+   end
 
-      local result = self.class.packages.inputfilter:transformContent(content, urlFilter, {
-        primaryPenalty = primaryPenalty,
-        secondaryPenalty = secondaryPenalty,
-        worsePenalty = worsePenalty
-      })
-      SILE.call("urlstyle", {}, result)
-    end)
-  end, "Inserts penalties in an URL so it can be broken over multiple lines at appropriate places.")
+   self:registerCommand("url", function (options, content)
+      SILE.settings:temporarily(function ()
+         local primaryPenalty = SILE.settings:get("url.linebreak.primaryPenalty")
+         local secondaryPenalty = SILE.settings:get("url.linebreak.secondaryPenalty")
+         local worsePenalty = primaryPenalty + secondaryPenalty
 
-  self:registerCommand("urlstyle", function (options, content)
-    SILE.call("code", options, content)
-  end, "Hook that may be redefined to change the styling of URLs")
+         if options.language then
+            SILE.languageSupport.loadLanguage(options.language)
+            if options.language == "fr" then
+               -- Trick the engine by declaring a "fake"" language that doesn't apply
+               -- the typographic rules for punctuations
+               SILE.hyphenator.languages["_fr_noSpacingRules"] = SILE.hyphenator.languages.fr
+               -- Not needed (the engine already defaults to SILE.nodeMakers.unicode if
+               -- the language is not found):
+               -- SILE.nodeMakers._fr_noSpacingRules = SILE.nodeMakers.unicode
+               SILE.settings:set("document.language", "_fr_noSpacingRules")
+            else
+               SILE.settings:set("document.language", options.language)
+            end
+         else
+            SILE.settings:set("document.language", "und")
+         end
 
+         local result = self.class.packages.inputfilter:transformContent(content, urlFilter, {
+            primaryPenalty = primaryPenalty,
+            secondaryPenalty = secondaryPenalty,
+            worsePenalty = worsePenalty,
+         })
+         SILE.call("urlstyle", {}, result)
+      end)
+   end, "Inserts penalties in an URL so it can be broken over multiple lines at appropriate places.")
+
+   self:registerCommand("urlstyle", function (options, content)
+      SILE.call("code", options, content)
+   end, "Hook that may be redefined to change the styling of URLs")
 end
 
 package.documentation = [[


### PR DESCRIPTION
Re-aligning modified packages and classes with SILE 0.15.9
 - Same styling conventions (3-space indentation etc.)
 - Small code re-alignments

This is mostly cosmetic, to make it easier checking which differences are still left now.
 - Most packages we had modified should be very close to SILE 0.15.9
 - The base class still has some differences (e.g. hanged indent, multiple instanciation cancellation, no landscape option), for consideration at a later point.