### PR TITLE
Anticipate changes for 0.15.10 backport in silex.sile

### DIFF
--- a/silex/typesetters/base.lua
+++ b/silex/typesetters/base.lua
@@ -150,6 +150,13 @@ function typesetter.declareSettings (_)
    })
 
    SILE.settings:declare({
+      parameter = "typesetter.brokenpenalty",
+      type = "integer",
+      default = 100,
+      help = "Penalty to be applied to broken (hyphenated) lines",
+   })
+
+   SILE.settings:declare({
       parameter = "typesetter.orphanpenalty",
       type = "integer",
       default = 3000,
@@ -723,6 +730,8 @@ function typesetter:boxUpNodes ()
          pageBreakPenalty = SILE.settings:get("typesetter.widowpenalty")
       elseif #lines > 1 and index == (#lines - 1) then
          pageBreakPenalty = SILE.settings:get("typesetter.orphanpenalty")
+      elseif line.is_broken then
+         pageBreakPenalty = SILE.settings:get("typesetter.brokenpenalty")
       end
       vboxes[#vboxes + 1] = self:leadingFor(vbox, self.state.previousVbox)
       vboxes[#vboxes + 1] = vbox
@@ -1336,12 +1345,16 @@ function typesetter:breakpointsToLines (breakpoints)
             SU.debug("typesetter", "Skipping a line containing only discardable nodes")
             linestart = point.position + 1
          else
+            local is_broken = false
             if slice[#slice].is_discretionary then
                -- The line ends, with a discretionary:
                -- repeat it on the next line, so as to account for a potential postbreak.
                linestart = point.position
                -- And mark it as used as prebreak for now.
                slice[#slice]:markAsPrebreak()
+               -- We'll want a "brokenpenalty" eventually (if not an orphan or widow)
+               -- to discourage page breaking after this line.
+               is_broken = true
             else
                linestart = point.position + 1
             end
@@ -1378,7 +1391,7 @@ function typesetter:breakpointsToLines (breakpoints)
                slice = self:_reboxLiners(slice)
             end
 
-            local thisLine = { ratio = ratio, nodes = slice }
+            local thisLine = { ratio = ratio, nodes = slice, is_broken = is_broken }
             lines[#lines + 1] = thisLine
 
             -- BEGIN SILEX HANGED LINES

--- a/silex/typesetters/base.lua
+++ b/silex/typesetters/base.lua
@@ -206,6 +206,13 @@ function typesetter.declareSettings (_)
    })
 
    SILE.settings:declare({
+      parameter = "typesetter.italicCorrection.punctuation",
+      type = "boolean",
+      default = true,
+      help = "Whether italic correction is compensated on special punctuation spaces (e.g. in French)",
+   })
+
+   SILE.settings:declare({
       parameter = "typesetter.softHyphen",
       type = "boolean",
       default = true,
@@ -513,9 +520,15 @@ function typesetter:breakIntoLines (nodelist, breakWidth)
    -- END SILEX HANGED LINES
 end
 
+--- Extract the last shaped item from a node list.
+-- @tparam table nodelist A list of nodes.
+-- @treturn table The last shaped item.
+-- @treturn boolean Whether the list contains a glue after the last shaped item.
+-- @treturn number|nil The width of a punctuation kern after the last shaped item, if any.
 local function getLastShape (nodelist)
+   local lastShape
    local hasGlue
-   local last
+   local punctSpaceWidth
    if nodelist then
       -- The node list may contain nnodes, penalties, kern and glue
       -- We skip the latter, and retrieve the last shaped item.
@@ -523,24 +536,33 @@ local function getLastShape (nodelist)
          local n = nodelist[i]
          if n.is_nnode then
             local items = n.nodes[#n.nodes].value.items
-            last = items[#items]
+            lastShape = items[#items]
             break
          end
          if n.is_kern and n.subtype == "punctspace" then
             -- Some languages such as French insert a special space around
-            -- punctuations. In those case, we should not need italic correction.
-            break
+            -- punctuations.
+            -- In those case, we have different strategies for handling
+            -- italic correction.
+            punctSpaceWidth = n.width:tonumber()
          end
          if n.is_glue then
             hasGlue = true
          end
       end
    end
-   return last, hasGlue
+   return lastShape, hasGlue, punctSpaceWidth
 end
+
+--- Extract the first shaped item from a node list.
+-- @tparam table nodelist A list of nodes.
+-- @treturn table The first shaped item.
+-- @treturn boolean Whether the list contains a glue before the first shaped item.
+-- @treturn number|nil The width of a punctuation kern before the first shaped item, if any.
 local function getFirstShape (nodelist)
-   local first
+   local firstShape
    local hasGlue
+   local punctSpaceWidth
    if nodelist then
       -- The node list may contain nnodes, penalties, kern and glue
       -- We skip the latter, and retrieve the first shaped item.
@@ -548,58 +570,73 @@ local function getFirstShape (nodelist)
          local n = nodelist[i]
          if n.is_nnode then
             local items = n.nodes[1].value.items
-            first = items[1]
+            firstShape = items[1]
             break
          end
          if n.is_kern and n.subtype == "punctspace" then
             -- Some languages such as French insert a special space around
-            -- punctuations. In those case, we should not need italic correction.
-            break
+            -- punctuations.
+            -- In those case, we have different strategies for handling
+            -- italic correction.
+            punctSpaceWidth = n.width:tonumber()
          end
          if n.is_glue then
             hasGlue = true
          end
       end
    end
-   return first, hasGlue
+   return firstShape, hasGlue, punctSpaceWidth
 end
 
-local function fromItalicCorrection (precShape, curShape)
+--- Compute the italic correction when switching from italic to non-italic.
+-- Computing italic correction is at best heuristics.
+-- The strong assumption is that italic is slanted to the right.
+-- Thus, the part of the character that goes beyond its width is usually maximal at the top of the glyph.
+-- E.g. consider a "f", that would be the top hook extent.
+-- Pathological cases exist, such as fonts with a Q with a long tail, but these will rarely occur in usual languages.
+-- For instance, Klingon's "QaQ" might be an issue, but there's not much we can do...
+-- Another assumption is that we can distribute that extent in proportion with the next character's height.
+-- This might not work that well with non-Latin scripts.
+--
+-- @tparam table precShape The last shaped item (italic).
+-- @tparam table curShape The first shaped item (non-italic).
+-- @tparam number|nil punctSpaceWidth The width of a punctuation kern between the two items, if any.
+local function fromItalicCorrection (precShape, curShape, punctSpaceWidth)
    local xOffset
    if not curShape or not precShape then
       xOffset = 0
+   elseif precShape.height <= 0 then
+      xOffset = 0
    else
-      -- Computing italic correction is at best heuristics.
-      -- The strong assumption is that italic is slanted to the right.
-      -- Thus, the part of the character that goes beyond its width is usually
-      -- maximal at the top of the glyph.
-      -- E.g. consider a "f", that would be the top hook extent.
-      -- Pathological cases exist, such as fonts with a Q with a long tail,
-      -- but these will rarely occur in usual languages. For instance, Klingon's
-      -- "QaQ" might be an issue, but there's not much we can do...
-      -- Another assumption is that we can distribute that extent in proportion
-      -- with the next character's height.
-      -- This might not work that well with non-Latin scripts.
       local d = precShape.glyphWidth + precShape.x_bearing
       local delta = d > precShape.width and d - precShape.width or 0
       xOffset = precShape.height <= curShape.height and delta or delta * curShape.height / precShape.height
+      if punctSpaceWidth and SILE.settings:get("typesetter.italicCorrection.punctuation") then
+         xOffset = xOffset - punctSpaceWidth > 0 and (xOffset - punctSpaceWidth) or 0
+      end
    end
    return xOffset
 end
 
-local function toItalicCorrection (precShape, curShape)
-   if not SILE.settings:get("typesetter.italicCorrection") then
-      return
-   end
+--- Compute the italic correction when switching from non-italic to italic.
+-- Same assumptions as fromItalicCorrection(), but on the starting side of the glyph.
+--
+-- @tparam table precShape The last shaped item (non-italic).
+-- @tparam table curShape The first shaped item (italic).
+-- @tparam number|nil punctSpaceWidth The width of a punctuation kern between the two items, if any.
+local function toItalicCorrection (precShape, curShape, punctSpaceWidth)
    local xOffset
    if not curShape or not precShape then
       xOffset = 0
+   elseif precShape.depth <= 0 then
+      xOffset = 0
    else
-      -- Same assumptions as fromItalicCorrection(), but on the starting side of
-      -- the glyph.
       local d = curShape.x_bearing
       local delta = d < 0 and -d or 0
       xOffset = precShape.depth >= curShape.depth and delta or delta * precShape.depth / curShape.depth
+      if punctSpaceWidth and SILE.settings:get("typesetter.italicCorrection.punctuation") then
+         xOffset = punctSpaceWidth - xOffset > 0 and xOffset or 0
+      end
    end
    return xOffset
 end
@@ -620,23 +657,24 @@ function typesetter.shapeAllNodes (_, nodelist, inplace)
    local newNodelist = {}
    local prec
    local precShapedNodes
+   local isItalicCorrectionEnabled = SILE.settings:get("typesetter.italicCorrection")
    for _, current in ipairs(nodelist) do
       if current.is_unshaped then
          local shapedNodes = current:shape()
 
-         if SILE.settings:get("typesetter.italicCorrection") and prec then
+         if isItalicCorrectionEnabled and prec then
             local itCorrOffset
             local isGlue
             if isItalicLike(prec) and not isItalicLike(current) then
                local precShape, precHasGlue = getLastShape(precShapedNodes)
-               local curShape, curHasGlue = getFirstShape(shapedNodes)
+               local curShape, curHasGlue, curPunctSpaceWidth = getFirstShape(shapedNodes)
                isGlue = precHasGlue or curHasGlue
-               itCorrOffset = fromItalicCorrection(precShape, curShape)
+               itCorrOffset = fromItalicCorrection(precShape, curShape, curPunctSpaceWidth)
             elseif not isItalicLike(prec) and isItalicLike(current) then
-               local precShape, precHasGlue = getLastShape(precShapedNodes)
+               local precShape, precHasGlue, precPunctSpaceWidth = getLastShape(precShapedNodes)
                local curShape, curHasGlue = getFirstShape(shapedNodes)
                isGlue = precHasGlue or curHasGlue
-               itCorrOffset = toItalicCorrection(precShape, curShape)
+               itCorrOffset = toItalicCorrection(precShape, curShape, precPunctSpaceWidth)
             end
             if itCorrOffset and itCorrOffset ~= 0 then
                -- If one of the node contains a glue (e.g. "a \em{proof} is..."),


### PR DESCRIPTION
Early adoption in our "modified" typesetter:
- [x] back port
    - https://github.com/sile-typesetter/sile/pull/2234
    - https://github.com/sile-typesetter/sile/pull/2221
- [x] dev release smoke tests
   - [x] check it corr
   - [x] check page breaks mve
- [x] tagged release